### PR TITLE
Add missing state translations

### DIFF
--- a/custom_components/ajax/translations/en.json
+++ b/custom_components/ajax/translations/en.json
@@ -414,6 +414,13 @@
       },
       "hub_gsm": {
         "name": "Hub GSM / SIM",
+        "state": {
+          "strong": "Strong",
+          "good": "Good",
+          "normal": "Normal",
+          "weak": "Weak",
+          "none": "None"
+        },
         "state_attributes": {
           "network_status": {
             "name": "Network status"


### PR DESCRIPTION
Adds missing state translations for the hub GSM sensor. I don't know what all of the possible states are so I copied from another sensor - and it works fine for the acual states I have seen on my hubs.