### PR TITLE
Move hassfest validation to separate workflow

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,19 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run hassfest
+        uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,15 +30,3 @@ jobs:
       # Formatting disabled - protobuf files have strict import dependencies
       # - name: Run ruff format check
       #   run: ruff format --check .
-
-  hassfest:
-    name: Hassfest Validation
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Run hassfest
-        uses: home-assistant/actions/hassfest@master


### PR DESCRIPTION
I recommend to move hassfest validation to a separate workflow. That way it can be run every 24 hours even if there is no other activity in the repo. It helps to catch errors early when HA team make changes in the validations.