### PR TITLE
New, minmalistic strategy for device names

### DIFF
--- a/custom_components/ajax/alarm_control_panel.py
+++ b/custom_components/ajax/alarm_control_panel.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, MANUFACTURER
 from .coordinator import AjaxDataCoordinator
 from .models import GroupState, SecurityState
 
@@ -120,8 +120,8 @@ class AjaxAlarmControlPanel(
 
         device_info = {
             "identifiers": {(DOMAIN, self._space_id)},
-            "name": f"Ajax Hub - {space.name}",
-            "manufacturer": "Ajax Systems",
+            "name": space.name,
+            "manufacturer": MANUFACTURER,
             "model": model_name,
         }
 

--- a/custom_components/ajax/binary_sensor.py
+++ b/custom_components/ajax/binary_sensor.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, MANUFACTURER
 from .coordinator import AjaxDataCoordinator
 from .devices import (
     ButtonHandler,
@@ -287,11 +287,6 @@ class AjaxBinarySensor(CoordinatorEntity[AjaxDataCoordinator], BinarySensorEntit
         if not device:
             return {}
 
-        # Include room name in device name if available
-        device_display_name = (
-            f"{device.room_name} - {device.name}" if device.room_name else device.name
-        )
-
         # Get model name - use raw_type from API (e.g., "DoorProtect Plus")
         model_name = device.raw_type or device.type.value.replace("_", " ").title()
         if device.device_color:
@@ -301,8 +296,8 @@ class AjaxBinarySensor(CoordinatorEntity[AjaxDataCoordinator], BinarySensorEntit
 
         info = {
             "identifiers": {(DOMAIN, self._device_id)},
-            "name": f"Ajax {device_display_name}",
-            "manufacturer": "Ajax Systems",
+            "name": device.name,
+            "manufacturer": MANUFACTURER,
             "model": model_name,
             "via_device": (DOMAIN, self._space_id),
             "sw_version": device.firmware_version,
@@ -394,21 +389,14 @@ class AjaxVideoEdgeBinarySensor(
         if not video_edge:
             return {}
 
-        # Include room name in device name if available
-        device_display_name = (
-            f"{video_edge.room_name} - {video_edge.name}"
-            if video_edge.room_name
-            else video_edge.name
-        )
-
         model_name = video_edge.video_edge_type.value
         if video_edge.color:
             model_name = f"{model_name} ({video_edge.color.title()})"
 
         info = {
             "identifiers": {(DOMAIN, self._video_edge_id)},
-            "name": f"Ajax {device_display_name}",
-            "manufacturer": "Ajax Systems",
+            "name": video_edge.name,
+            "manufacturer": MANUFACTURER,
             "model": model_name,
             "via_device": (DOMAIN, self._space_id),
             "sw_version": video_edge.firmware_version,

--- a/custom_components/ajax/button.py
+++ b/custom_components/ajax/button.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, MANUFACTURER
 from .coordinator import AjaxDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -76,8 +76,8 @@ class AjaxPanicButton(CoordinatorEntity[AjaxDataCoordinator], ButtonEntity):
 
         return {
             "identifiers": {(DOMAIN, self._space_id)},
-            "name": f"Ajax Hub - {space.name}",
-            "manufacturer": "Ajax Systems",
+            "name": space.name,
+            "manufacturer": MANUFACTURER,
             "model": "Security Hub",
             "sw_version": None,  # TODO: Add hub firmware version when available
         }

--- a/custom_components/ajax/const.py
+++ b/custom_components/ajax/const.py
@@ -3,6 +3,9 @@
 # Integration domain
 DOMAIN = "ajax"
 
+# Global/general strings
+MANUFACTURER = "Ajax Systems"
+
 # Configuration and defaults
 CONF_API_KEY = "api_key"
 CONF_EMAIL = "email"

--- a/custom_components/ajax/device_tracker.py
+++ b/custom_components/ajax/device_tracker.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, MANUFACTURER
 from .coordinator import AjaxDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -139,8 +139,8 @@ class AjaxHubTracker(CoordinatorEntity[AjaxDataCoordinator], TrackerEntity):
 
         return {
             "identifiers": {(DOMAIN, self._space_id)},
-            "name": "Ajax Hub" if space.name == "Hub" else f"Ajax Hub - {space.name}",
-            "manufacturer": "Ajax Systems",
+            "name": "Ajax Hub" if space.name == "Hub" else space.name,
+            "manufacturer": MANUFACTURER,
         }
 
     @callback

--- a/custom_components/ajax/sensor.py
+++ b/custom_components/ajax/sensor.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, MANUFACTURER
 from .coordinator import AjaxDataCoordinator
 from .devices import (
     ButtonHandler,
@@ -647,13 +647,11 @@ class AjaxSpaceSensor(CoordinatorEntity[AjaxDataCoordinator], SensorEntity):
         if not space:
             return {}
 
-        hub_display_name = (
-            "Ajax Hub" if space.name == "Hub" else f"Ajax Hub - {space.name}"
-        )
+        hub_display_name = "Ajax Hub" if space.name == "Hub" else space.name
         device_info = {
             "identifiers": {(DOMAIN, self._space_id)},
             "name": hub_display_name,
-            "manufacturer": "Ajax Systems",
+            "manufacturer": MANUFACTURER,
             "model": format_hub_type(space.hub_details.get("hubSubtype"))
             if space.hub_details
             else "Security Hub",
@@ -757,14 +755,10 @@ class AjaxDeviceSensor(CoordinatorEntity[AjaxDataCoordinator], SensorEntity):
         if not device:
             return {}
 
-        device_display_name = (
-            f"{device.room_name} - {device.name}" if device.room_name else device.name
-        )
-
         info = {
             "identifiers": {(DOMAIN, self._device_id)},
-            "name": f"Ajax {device_display_name}",
-            "manufacturer": "Ajax Systems",
+            "name": device.name,
+            "manufacturer": MANUFACTURER,
             "model": device.raw_type,
             "via_device": (DOMAIN, self._space_id),
             "sw_version": device.firmware_version,
@@ -872,20 +866,14 @@ class AjaxVideoEdgeSensor(CoordinatorEntity[AjaxDataCoordinator], SensorEntity):
         if not video_edge:
             return {}
 
-        device_display_name = (
-            f"{video_edge.room_name} - {video_edge.name}"
-            if video_edge.room_name
-            else video_edge.name
-        )
-
         model_name = video_edge.video_edge_type.value
         if video_edge.color:
             model_name = f"{model_name} ({video_edge.color.title()})"
 
         info = {
             "identifiers": {(DOMAIN, self._video_edge_id)},
-            "name": f"Ajax {device_display_name}",
-            "manufacturer": "Ajax Systems",
+            "name": video_edge.name,
+            "manufacturer": MANUFACTURER,
             "model": model_name,
             "via_device": (DOMAIN, self._space_id),
             "sw_version": video_edge.firmware_version,

--- a/custom_components/ajax/switch.py
+++ b/custom_components/ajax/switch.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, MANUFACTURER
 from .coordinator import AjaxDataCoordinator
 from .devices import (
     ButtonHandler,
@@ -398,15 +398,10 @@ class AjaxSwitch(CoordinatorEntity[AjaxDataCoordinator], SwitchEntity):
         if not device:
             return {}
 
-        # Include room name in device name if available
-        device_display_name = (
-            f"{device.room_name} - {device.name}" if device.room_name else device.name
-        )
-
         info = {
             "identifiers": {(DOMAIN, self._device_id)},
-            "name": f"Ajax {device_display_name}",
-            "manufacturer": "Ajax Systems",
+            "name": device.name,
+            "manufacturer": MANUFACTURER,
             "model": device.raw_type,
             "via_device": (DOMAIN, self._space_id),
             "sw_version": device.firmware_version,


### PR DESCRIPTION
To get a smooth user experience and align with best practise in HA the naming of devices is changed so that the device name is just the device name that is set in Ajax app.
- "Ajax Hallway - Door" becomes "Door"
Consequences:
 - Less cluttered impression in the UI, especially in the pending new style for default dashboard
 - Users don't have to rename the devices when changing their area assignment in HA
 - Can break automations and scripts

As this is a somewhat breaking change, I think it is better to do it ASAP while the user count is moderate. 

Next step (another PR) is to use default naming of the featured entity of devices where appropriate.
 - The door sensor in a DoorProtect device should be assigned None as name in HA. More on this in a follow up PR.

Excuse for the Swedish screenshots, but I hope you see the points.

### Current Home dashboard
<img width="790" height="435" alt="image" src="https://github.com/user-attachments/assets/69c439a4-75b1-458d-8511-d74cce1ff259" />

### Suggested naming strategy

<img width="779" height="490" alt="image" src="https://github.com/user-attachments/assets/40426eff-55db-4941-822b-0979a13fe34a" />

**Note** that "Dörr Dörr" will be changed to "Dörr" in a follow-up PR.

<img width="572" height="612" alt="image" src="https://github.com/user-attachments/assets/161c93e3-d0cf-4264-8b38-de6dd34bcaed" />
