### PR TITLE
Add single device mode to diagnostics

### DIFF
--- a/custom_components/ajax/diagnostics.py
+++ b/custom_components/ajax/diagnostics.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from contextlib import suppress
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -35,14 +34,15 @@ async def get_ajax_raw_data(
     all_cameras = []
     all_video_edges = []
     hub_count = 0
-    target_device_id: str | None = None
 
-    with suppress(StopIteration):
-        target_device_id = (
-            next(str(value) for domain, value in device.identifiers if domain == DOMAIN)
-            if device is not None
-            else None
+    target_device_id = (
+        next(
+            (str(value) for domain, value in device.identifiers if domain == DOMAIN),
+            None,
         )
+        if device is not None
+        else None
+    )
 
     if coordinator.account:
         for _space_id, space in coordinator.account.spaces.items():


### PR DESCRIPTION
Add single device mode to diagnostics platform.
- When you intitate diagnostics download from integration page a dump of all devices is generated as before.
- When the dump is initiated from a device page, only the device in focus is dumped. This reduces clutter and saves a number of API calls.

I have no knowledge of how video edge devices are represented so I did not add the filtering logic in that loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added device-scoped diagnostics so diagnostics can be requested for an individual device, enabling more granular troubleshooting.
  * Per-device diagnostics return redacted device info, related entry config, and diagnostics data filtered to that device while preserving existing overall diagnostics behavior.

* **Chores**
  * Made diagnostics data redaction and handling more consistent across outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->