### PR TITLE
Prevent integration from being setup twice with same account

### DIFF
--- a/custom_components/ajax/__init__.py
+++ b/custom_components/ajax/__init__.py
@@ -539,7 +539,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-async def async_migrate_entry(hass: HomeAssistant, entry: AjaxConfigEntry) -> bool:
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old entry."""
     # Add unique_id
     if entry.version == 1 and entry.minor_version == 1:


### PR DESCRIPTION
Add a unique_id to the config entry prevents the integration to be setup twice with same account. Allowing this would generate massive duplicate entry errors and lead to unpredictable behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration Migration: Automatically updates and migrates existing account setups when new application versions are released to ensure full compatibility
  * Account Protection: Unique account identification system implemented to prevent users from accidentally adding duplicate accounts

* **Improvements**
  * Enhanced configuration flow validation for more stable account management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->