### PR TITLE
Dhcp discovery

### DIFF
--- a/custom_components/ajax/manifest.json
+++ b/custom_components/ajax/manifest.json
@@ -8,6 +8,10 @@
     {
       "hostname": "ajax-*",
       "macaddress": "9C756E*"
+    },
+    {
+      "hostname": "ajax-*",
+      "macaddress": "38B8EB*"
     }
   ],
   "documentation": "https://github.com/foXaCe/ajax-security-hass",


### PR DESCRIPTION
Home Assistant can discover devices on the LAN and hint the user to install an integration.
Ajax hubs don't advertise their presence actively but as HA monitors the DHCP traffic on the LAN  it can still discover Ajax hubs.

Note that this feature only works if the integration is downloaded to `custom_components`. If the integration is moved to core in the future, the function will be there by default. Also note that it can take a couple of hours until a hub is discovered, depending on the settings in the DHCP server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded device discovery capabilities to automatically recognize and configure additional device variants, improving the initial setup experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->