### PR TITLE
Improve sqs handler : make message visible again

### DIFF
--- a/custom_components/ajax/sqs_client.py
+++ b/custom_components/ajax/sqs_client.py
@@ -206,23 +206,22 @@ class AjaxSQSClient:
             if self._callback and self._hass_loop:
                 future = asyncio.run_coroutine_threadsafe(self._callback(body), self._hass_loop)
                 # Wait for callback to complete (with timeout)
-                try:
-                    if not future.result(timeout=15):
-                        try:
-                            async with self._make_client() as client:
-                                await client.change_message_visibility(
-                                    QueueUrl=self._queue_url,
-                                    ReceiptHandle=receipt,
-                                    VisibilityTimeout=0,
-                                )
-                            _LOGGER.debug("SQS: message made visible again %s", msg_id)
-                        except Exception as requeue_err:
-                            _LOGGER.error(
-                                "SQS: failed to make message visible again %s: %s",
-                                msg_id,
-                                requeue_err,
+                if not future.result(timeout=15):
+                    try:
+                        async with self._make_client() as client:
+                            await client.change_message_visibility(
+                                QueueUrl=self._queue_url,
+                                ReceiptHandle=receipt,
+                                VisibilityTimeout=0,
                             )
-                        return
+                        _LOGGER.debug("SQS: message made visible again %s", msg_id)
+                    except Exception as requeue_err:
+                        _LOGGER.error(
+                            "SQS: failed to make message visible again %s: %s",
+                            msg_id,
+                            requeue_err,
+                        )
+                    return
 
             # Delete message from queue
             async with self._make_client() as client:


### PR DESCRIPTION
## Description

This PR set message visibility to 0 if not handle by this instance of integration

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement

## Related Issues

N/A

## Checklist

- [X] My code follows the project's coding style (ruff check passes)
- [X] I have tested my changes locally with Home Assistant
- [ ] I have updated the CHANGELOG.md if applicable
- [ ] I have updated documentation if applicable
- [X] My changes don't introduce new warnings or errors

## Testing

<!-- Describe how you tested your changes -->

- [X] Tested with Home Assistant version: 2026.2.2
- [X] Tested with Ajax device types: hub2 plus, motion (plus and normal), door protect (plus and normal), space control....

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information reviewers should know -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Messages that previously looked like failed processing are now re-queued for immediate retry to reduce message loss.
  * Re-queue operations make retried messages available right away, improving throughput during transient failures.
  * Added debug and error logging around re-queue attempts and streamlined error handling for clearer troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->