### PR TITLE
fix: handle WallSwitch Jeweller relay events triggered by arm/disarm

### DIFF
--- a/custom_components/ajax/coordinator.py
+++ b/custom_components/ajax/coordinator.py
@@ -2954,6 +2954,8 @@ class AjaxDataCoordinator(DataUpdateCoordinator[AjaxAccount]):
             "socket_outlet_type_f": DeviceType.SOCKET,
             "relay": DeviceType.RELAY,
             "wallswitch": DeviceType.WALLSWITCH,
+            "wall_switch": DeviceType.WALLSWITCH,
+            "wall_switch_jeweller": DeviceType.WALLSWITCH,
             "lightswitch": DeviceType.WALLSWITCH,
             "lightswitchonegang": DeviceType.WALLSWITCH,
             "lightswitchtwogang": DeviceType.WALLSWITCH,

--- a/custom_components/ajax/sqs_manager.py
+++ b/custom_components/ajax/sqs_manager.py
@@ -123,6 +123,12 @@ RELAY_EVENTS = {
     "turnedoff": ("light_off", False),
     "relayonbyuser": ("relay_on", True),
     "relayoffbyuser": ("relay_off", False),
+    # WallSwitch Jeweller — relay toggled automatically on arm/disarm
+    # eventTypeV2=SMART_HOME_ACTUATOR, sourceObjectType=WALL_SWITCH
+    "relayonbyarming": ("relay_on_by_arming", True),
+    "relayoffbyarming": ("relay_off_by_arming", False),
+    "relayonbydisarming": ("relay_on_by_disarming", True),
+    "relayoffbydisarming": ("relay_off_by_disarming", False),
 }
 
 BUTTON_EVENTS = {


### PR DESCRIPTION
## Description

The WallSwitch Jeweller (`sourceObjectType: WALL_SWITCH`, `eventTypeV2: SMART_HOME_ACTUATOR`) 
can be configured in the Ajax app to automatically toggle its relay when the security system 
arms or disarms. This generates SSE events with tags `RelayOnByArming`, `RelayOffByArming`, 
`RelayOnByDisarming` and `RelayOffByDisarming` — none of which were handled, causing 
repeated `SSE event not handled` warnings in the Home Assistant logs.

Additionally, the Ajax REST API returns the device type as `WALL_SWITCH` (uppercase with 
underscore) for this device. This string was not present in the `_parse_device_type` mapping, 
causing the device to be classified as `DeviceType.UNKNOWN` instead of `DeviceType.WALLSWITCH`.

### Changes

**`sqs_manager.py`** — Added 4 entries to `RELAY_EVENTS`:
- `relayonbyarming` → `("relay_on_by_arming", True)`
- `relayoffbyarming` → `("relay_off_by_arming", False)`
- `relayonbydisarming` → `("relay_on_by_disarming", True)`
- `relayoffbydisarming` → `("relay_off_by_disarming", False)`

These events are shared between `SSEManager` and `SQSManager` (the dict is imported by both), 
so both real-time and polling paths are covered. The `is_on` device attribute is updated 
immediately upon receipt of the SSE event.

**`coordinator.py`** — Added 2 aliases in `_parse_device_type`:
- `"wall_switch"` → `DeviceType.WALLSWITCH`
- `"wall_switch_jeweller"` → `DeviceType.WALLSWITCH`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

<!-- No existing issue — discovered on WallSwitch Jeweller configured as alarm status indicator -->

## Checklist

- [x] My code follows the project's coding style (ruff check passes)
- [x] I have tested my changes locally with Home Assistant
- [x] I have updated the CHANGELOG.md if applicable
- [x] My changes don't introduce new warnings or errors

## Testing

- [x] Tested with Home Assistant version: 2025.4
- [x] Tested with Ajax device types: WallSwitch Jeweller (`WALL_SWITCH`)

**Before fix** — on every arm/disarm cycle:
WARNING SSE event not handled: tag=relayonbydisarming, type=WALL_SWITCH,
typeV2=SMART_HOME_ACTUATOR, source=Statut alarme (id=30FF5F82)
WARNING SSE event not handled: tag=relayonbyarming, type=WALL_SWITCH,
typeV2=SMART_HOME_ACTUATOR, source=Statut alarme (id=30FF5F82)

**After fix** — on every arm/disarm cycle:
INFO SSE instant: Statut alarme -> relay_on_by_disarming
INFO SSE instant: Statut alarme -> relay_on_by_arming

## Additional Notes

The WallSwitch Jeweller used as an alarm status indicator behaves as read-only from a 
Home Assistant perspective: even if the switch entity is turned off via HA, Ajax will 
immediately re-trigger `RelayOnByArming` (since the system is armed), causing the HA 
state to revert to `on`. This is expected behavior — the device's relay is under Ajax 
automation control. Users relying on this device as a status indicator should expose it 
as a `binary_sensor` template rather than a controllable switch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device type recognition for additional wall switch variants, ensuring all supported naming conventions are properly identified and classified.
  * Enhanced relay state handling for wall switches during security mode transitions, including arming and disarming actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->