### PR TITLE
fix: fire security state event unconditionally from SSE/SQS

### DIFF
--- a/custom_components/ajax/sqs_manager.py
+++ b/custom_components/ajax/sqs_manager.py
@@ -643,15 +643,21 @@ class SQSManager(EventHandlerMixin):
 
         # Fire HA bus event so automations can branch on who triggered
         # the arm/disarm (user name, keypad, space control, HA...).
-        if state_changed:
-            self.coordinator._fire_security_state_event(
-                space,
-                old_state,
-                new_state,
-                source_name=source_name,
-                source_type=source_type,
-            )
-
+        # if state_changed:
+        #     self.coordinator._fire_security_state_event(
+        #         space,
+        #         old_state,
+        #         new_state,
+        #         source_name=source_name,
+        #         source_type=source_type,
+        #     )
+        self.coordinator._fire_security_state_event(
+            space,
+            old_state,
+            new_state,
+            source_name=source_name,
+            source_type=source_type,
+        )
         return True
 
     async def _handle_door_event(

--- a/custom_components/ajax/sse_manager.py
+++ b/custom_components/ajax/sse_manager.py
@@ -446,7 +446,7 @@ class SSEManager(EventHandlerMixin):
             new_state,
             source_name=source_name,
             source_type=source_type,
-        )        
+        )
 
     def _find_device(self, space, source_name: str, source_id: str):
         """Find device by name or ID.

--- a/custom_components/ajax/sse_manager.py
+++ b/custom_components/ajax/sse_manager.py
@@ -432,14 +432,21 @@ class SSEManager(EventHandlerMixin):
         # Fire HA bus event so automations can react to who triggered the
         # arm/disarm (user name, keypad, space control, HA...) — otherwise
         # only the coordinator REST fallback fires it without source info.
-        if state_changed:
-            self.coordinator._fire_security_state_event(
-                space,
-                old_state,
-                new_state,
-                source_name=source_name,
-                source_type=source_type,
-            )
+        # if state_changed:
+        #     self.coordinator._fire_security_state_event(
+        #         space,
+        #         old_state,
+        #         new_state,
+        #         source_name=source_name,
+        #         source_type=source_type,
+        #     )
+        self.coordinator._fire_security_state_event(
+            space,
+            old_state,
+            new_state,
+            source_name=source_name,
+            source_type=source_type,
+        )        
 
     def _find_device(self, space, source_name: str, source_id: str):
         """Find device by name or ID.


### PR DESCRIPTION
## Problem

`_fire_security_state_event` was gated on `state_changed=True` in both
`sse_manager.py` and `sqs_manager.py`. When the REST polling had already
consumed the state change before SSE/SQS processed the event,
`old_state == new_state` → `state_changed=False` → the HA bus event
(`ajax_armed`, `ajax_disarmed`, `ajax_armed_night`, `ajax_armed_home`)
was never fired.

## Root cause

The `_skip_state_change_event` flag was designed to prevent the REST
poller from duplicating the event when SSE/SQS "already created it" —
but SSE/SQS only created it `if state_changed`, making the deduplication
suppress the only fire that would have worked.

## Fix

Call `_fire_security_state_event` unconditionally from SSE/SQS. They are
the authoritative source with `source_name`/`source_type`. The
`_skip_state_change_event` flag already ensures the REST poller does not
fire a duplicate.

## Tested

Verified on Hub Plus with `nightmodeon`/`nightmodeoff` events where
`state_changed=False` due to optimistic update. Both `ajax_armed_night`
and `ajax_disarmed` now appear in Developer Tools → Events.

Closes #93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Security state events are now unconditionally dispatched for all processed security events. This improves overall consistency in event handling and ensures complete notifications across all security state transitions, even when internal state computations indicate unchanged values. Event dispatch behavior is now more predictable and operationally reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->