### PR TITLE
fix(devices): map RangeExtender (Rex 1/2) raw types explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **RangeExtender 2 (Rex 2) had no explicit device-type mapping (#167).** The raw Ajax types `RangeExtender` (Rex 1) and `RangeExtender2` (Rex 2) only resolved to a repeater by accident, via the `"extender"` substring fallback — so a future unrelated device whose raw name happened to contain `extender` could have been silently misclassified instead of surfacing as `UNKNOWN` with a warning. Both types now map explicitly.
+
 ## [0.33.0] - 2026-06-24
 
 ### Fixed

--- a/custom_components/ajax/_coordinator_state.py
+++ b/custom_components/ajax/_coordinator_state.py
@@ -208,6 +208,10 @@ _DEVICE_TYPE_MAP: dict[str, DeviceType] = {
     "repeater": DeviceType.REPEATER,
     "rex": DeviceType.REPEATER,
     "range_extender": DeviceType.REPEATER,
+    # Explicit raw Ajax types (Rex 1 / Rex 2) so they match exactly instead of
+    # relying on the "extender" substring fallback — see issue #167.
+    "rangeextender": DeviceType.REPEATER,
+    "rangeextender2": DeviceType.REPEATER,
     "extender": DeviceType.REPEATER,
     # Wired Input Modules
     "wire_input_mt": DeviceType.WIRE_INPUT,

--- a/tests/test_coordinator_parsers.py
+++ b/tests/test_coordinator_parsers.py
@@ -69,6 +69,12 @@ def test_parse_device_type_resolves_known_alias(parser: AjaxStateUpdaterMixin) -
     assert parser._parse_device_type("MotionProtect") is DeviceType.MOTION_DETECTOR
 
 
+def test_parse_device_type_resolves_range_extender_variants(parser: AjaxStateUpdaterMixin) -> None:
+    """Rex 1 / Rex 2 raw types map explicitly, not via the 'extender' substring fallback (#167)."""
+    assert parser._parse_device_type("RangeExtender") is DeviceType.REPEATER
+    assert parser._parse_device_type("RangeExtender2") is DeviceType.REPEATER
+
+
 def test_parse_device_type_strips_trailing_braces(parser: AjaxStateUpdaterMixin) -> None:
     """The Ajax API occasionally ships values like 'wire_input_mt {\\n}\\n' — must still resolve."""
     assert parser._parse_device_type("wire_input_mt {\n}\n") is DeviceType.WIRE_INPUT


### PR DESCRIPTION
## Summary

Adds explicit `_DEVICE_TYPE_MAP` entries for the RangeExtender raw types, as reported in #167 by @wvnispen.

Ajax's raw `deviceType` is `RangeExtender` (Rex 1) / `RangeExtender2` (Rex 2). Neither had an explicit key in `_DEVICE_TYPE_MAP` — they only resolved to `DeviceType.REPEATER` by accident, via the `"extender"` substring fallback in `_parse_device_type()`.

## Why it matters

It works today, but it is fragile: if Ajax ever ships an unrelated device type whose raw name happens to contain `extender`, the substring fallback would **silently** misclassify it as a repeater instead of falling through to `UNKNOWN` with a warning — losing the log visibility that helps catch new device types.

## Change

```python
"rangeextender": DeviceType.REPEATER,   # Rex 1 raw type "RangeExtender"
"rangeextender2": DeviceType.REPEATER,  # Rex 2 raw type "RangeExtender2"
```

Both now match exactly (before the substring fallback). Added a regression test in `test_coordinator_parsers.py`.

## Verification

- `ruff` + `mypy --strict` clean; full suite green (1885 tests, +1).

Refs #167.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device type recognition for RangeExtender and RangeExtender 2 devices.
  * These devices are now classified correctly as repeaters, reducing the chance of misidentifying unrelated devices.
  * Added coverage to confirm both variants are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->