### PR TITLE
ci(renovate): bump >= range floors to latest (rangeStrategy: bump)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "rangeStrategy": "bump",
   "packageRules": [
     {
       "description": "Maintain Home Assistant compatibility: only allow patch updates for grpcio and protobuf (block major and minor), matching the previous Dependabot ignore rule",


### PR DESCRIPTION
## Why

Renovate stopped opening dependency PRs even though newer versions exist. It is **not** broken — the Dependency Dashboard (#164) shows no errors and detects every dependency. The cause is the default `rangeStrategy` (`auto` → `replace`): it never bumps a `>=X` floor that **already** allows the latest version, so all of my `>=`-pinned Python deps were silently considered up to date.

Updates that were invisible:

| Package | Floor | Latest |
|---|---|---|
| `pytest-homeassistant-custom-component` | `>=0.13.339` | 0.13.341 |
| `onvif-zeep-async` | `>=3.1.12` | **4.2.0** (major) |
| `aiobotocore` (manifest.json) | `>=2.22.0` | 3.7.0 |

## Change

Add `"rangeStrategy": "bump"` so Renovate raises the `>=` floor to the current latest on each release, turning these into reviewable PRs.

```json
"rangeStrategy": "bump"
```

Validated with `renovate-config-validator` ("Config validated successfully").

## Notes

- Expect ~3 PRs after the next Renovate run, including a **major** `onvif-zeep-async` 3.x → 4.x bump worth reviewing (`onvif_client.py` depends on it).
- `pytest-homeassistant-custom-component` releases often, so it will generate frequent PRs — we can group/schedule them later if that gets noisy.
- The existing grpcio/protobuf patch-only rule is unchanged.
