### PR TITLE
ci(renovate): auto-merge non-major updates on green CI

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,8 @@
     "config:recommended"
   ],
   "rangeStrategy": "bump",
+  "platformAutomerge": false,
+  "automergeStrategy": "squash",
   "packageRules": [
     {
       "description": "Maintain Home Assistant compatibility: only allow patch updates for grpcio and protobuf (block major and minor), matching the previous Dependabot ignore rule",
@@ -16,6 +18,16 @@
         "minor"
       ],
       "enabled": false
+    },
+    {
+      "description": "Auto-merge non-major updates once CI is green; major updates stay manual for review",
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "pin"
+      ],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Why

Renovate does not auto-merge by default (`config:recommended` doesn't enable it), so every dependency PR has to be merged by hand. This enables auto-merge for routine, low-risk updates while keeping majors for manual review.

## Change

- **Auto-merge** `minor` / `patch` / `digest` / `pin` updates once CI is green (GitHub Actions, test deps, non-major library floors).
- **Major** updates (e.g. `onvif-zeep-async` 3.x → 4.x, `aiobotocore` 2.x → 3.x) stay **manual** — they need review/testing.
- `platformAutomerge: false`: `main` has no required status checks, so GitHub's native auto-merge is unavailable; Renovate self-merges (`automergeStrategy: squash`, matching the repo convention) once it sees the CI checks pass.

Renovate only merges on green CI, so a bump that breaks `Tests` / `mypy` / `Hassfest` won't land.

Validated with `renovate-config-validator` ("Config validated successfully").

## Note

For the most robust gating you could later add branch protection on `main` requiring the CI checks (then GitHub's native auto-merge could be used). Not required for this to work.
