### PR TITLE
fix(events): route smart-lock LIFECYCLE events to debug, not a warning (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Smart-lock "object added" lifecycle events no longer spam the log with a warning (#88).** Ajax `LIFECYCLE` notices (e.g. `ObjectAdded` when a LockBridge / smart lock is paired) were logged as `SSE/SQS event not handled` warnings. They carry no per-device state — the periodic poll reconciles the device list — so they are now logged at debug level instead.
+
 ## [0.33.1] - 2026-06-25
 
 ### Fixed

--- a/custom_components/ajax/sqs_manager.py
+++ b/custom_components/ajax/sqs_manager.py
@@ -275,6 +275,16 @@ class SQSManager(EventHandlerMixin):
                 await self._handle_lock_event(space, event_tag, source_name, source_id, event_code, event)
             elif event_tag in HUB_EVENTS:
                 _LOGGER.info("SQS: Hub event: %s (%s)", event_tag, source_name)
+            elif event_type == "LIFECYCLE":
+                # Device add/remove/(de)activate notices carry no per-device
+                # state; the poll reconciles devices, so log at debug instead of
+                # an "unhandled" warning (parity with sse_manager, #88).
+                _LOGGER.debug(
+                    "SQS: lifecycle event %s (%s, id=%s) - ignored",
+                    event_tag,
+                    source_name,
+                    source_id,
+                )
             else:
                 _LOGGER.warning(
                     "SQS event not handled: tag=%s, type=%s, source=%s (id=%s). Raw: %s",

--- a/custom_components/ajax/sse_manager.py
+++ b/custom_components/ajax/sse_manager.py
@@ -333,6 +333,16 @@ class SSEManager(EventHandlerMixin):
                 self._handle_lock_event(space, event_tag, source_name, source_id, event_code, event)
             elif event_tag in HUB_EVENTS:
                 _LOGGER.info("SSE: Hub event: %s (%s)", event_tag, source_name)
+            elif event_type_v2 == "LIFECYCLE":
+                # Device add/remove/(de)activate notices (e.g. ObjectAdded) carry
+                # no per-device state; the periodic poll reconciles the device
+                # list, so log at debug instead of an "unhandled" warning (#88).
+                _LOGGER.debug(
+                    "SSE: lifecycle event %s (%s, id=%s) - ignored",
+                    event_tag,
+                    source_name,
+                    source_id,
+                )
             else:
                 _LOGGER.warning(
                     "SSE event not handled: tag=%s, type=%s, typeV2=%s, source=%s (id=%s). Raw: %s",

--- a/tests/test_sqs_manager_coverage.py
+++ b/tests/test_sqs_manager_coverage.py
@@ -18,6 +18,7 @@ These tests build a manager via ``object.__new__`` and wire a fake coordinator
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -132,6 +133,22 @@ def _event(**overrides) -> dict:
     }
     event.update(overrides)
     return {"event": event}
+
+
+# ---------------------------------------------------------------------------
+# _handle_event dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_event_lifecycle_ignored_without_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """LIFECYCLE notices (e.g. ObjectAdded) route to debug, not an 'unhandled' warning (#88)."""
+    mgr = _make_manager()
+    _with_space(mgr, _space())
+    with caplog.at_level(logging.WARNING, logger="custom_components.ajax.sqs_manager"):
+        await mgr._handle_event(_event(eventTag="ObjectAdded", eventTypeV2="LIFECYCLE"))
+    assert "not handled" not in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sse_manager_coverage.py
+++ b/tests/test_sse_manager_coverage.py
@@ -13,6 +13,7 @@ coordinator so no network round-trip or full HA harness is needed.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -219,6 +220,24 @@ async def test_handle_event_unknown_hub_returns_early() -> None:
     _attach(mgr, _space())  # hub_id = hub1
     await mgr._handle_event({"eventTag": "dooropened", "hubId": "OTHER"})
     mgr.coordinator.async_set_updated_data.assert_not_called()
+
+
+async def test_handle_event_lifecycle_ignored_without_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """LIFECYCLE notices (e.g. ObjectAdded) route to debug, not an 'unhandled' warning (#88)."""
+    mgr = _make_manager()
+    _attach(mgr, _space())  # hub_id = hub1
+    with caplog.at_level(logging.WARNING, logger="custom_components.ajax.sse_manager"):
+        await mgr._handle_event(
+            {
+                "eventTag": "ObjectAdded",
+                "eventTypeV2": "LIFECYCLE",
+                "hubId": "hub1",
+                "sourceObjectId": "lock1",
+            }
+        )
+    assert "not handled" not in caplog.text
 
 
 async def test_handle_event_nested_format_dispatches_door() -> None:


### PR DESCRIPTION
## Summary

Stops the log noise reported by a LockBridge user in #88: Ajax `LIFECYCLE` notices (e.g. `ObjectAdded` when a smart lock is paired) were logged as `SSE/SQS event not handled` **warnings**:

```
WARNING [custom_components.ajax.sse_manager] SSE event not handled: tag=objectadded, type=SMART_LOCK, typeV2=LIFECYCLE, ...
```

## Change

- Both the SSE and SQS dispatchers now route `eventTypeV2 == "LIFECYCLE"` events to a **debug** log instead of the "unhandled" warning. These notices carry no per-device state — the periodic device poll reconciles add/remove — so there is nothing to act on.
- Regression tests in `test_sse_manager_coverage.py` / `test_sqs_manager_coverage.py` assert a LIFECYCLE event no longer produces the "not handled" warning.

## Scope

This is the log-noise part of #88 only. It does **not** address the core smart-lock state issue in that thread (a Yale Doorman V2N that emits no `smartlock*` events) — the Ajax REST smart-lock endpoint returns no lock state (only `id`), so state is event-only and can't be synthesised when the hardware sends no events.

Refs #88.
