### PR TITLE
fix(coordinator): read smart-lock state from the enriched device record (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Smart-lock state now updates by polling, even when the lock sends no real-time events (#88).** A bridged lock (e.g. a Yale Doorman behind a LockBridge) can be discovered but never emit `smartlock*` SSE/SQS events, leaving its lock/door state stuck on *unknown*. The state (`lockStatus` / `doorStatus`) is now read from the enriched hub-device record on every poll; a recent real-time event still takes precedence over the slower poll.
+
 ## [0.33.2] - 2026-06-27
 
 ### Fixed

--- a/custom_components/ajax/_coordinator_devices.py
+++ b/custom_components/ajax/_coordinator_devices.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import TYPE_CHECKING
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -35,7 +36,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
     from .api import AjaxRestApi
-    from .models import AjaxAccount
+    from .models import AjaxAccount, AjaxSpace
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -108,6 +109,26 @@ class AjaxDevicesMixin(AjaxDeviceNormalizeMixin):
                 len(stale_devices),
             )
 
+    def _apply_smart_lock_rest_state(self, space: AjaxSpace, device_id: str, device_data: dict[str, Any]) -> None:
+        """Apply a smart lock's state from its enriched hub-device record.
+
+        The dedicated smart-locks endpoint exposes no lock state, and
+        Yale-bridged locks emit no ``smartlock*`` events, so the device record's
+        ``lockStatus`` / ``doorStatus`` is the only state source for them (#88).
+        A real-time event is fresher than the poll, so a recent one wins.
+        """
+        lock = space.smart_locks.get(device_id)
+        if lock is None:
+            return  # not discovered yet; applied on a later poll cycle
+        if lock.last_event_time is not None and (datetime.now(UTC) - lock.last_event_time).total_seconds() < 30:
+            return
+        lock_status = device_data.get("lockStatus")
+        if lock_status in ("LOCKED", "UNLOCKED"):
+            lock.is_locked = lock_status == "LOCKED"
+        door_status = device_data.get("doorStatus")
+        if door_status in ("OPEN", "CLOSED"):
+            lock.is_door_open = door_status == "OPEN"
+
     async def _async_update_devices(self, space_id: str) -> None:
         """Update devices for a specific space."""
         if self.account is None:
@@ -163,12 +184,14 @@ class AjaxDevicesMixin(AjaxDeviceNormalizeMixin):
             raw_device_type = device_data.get("deviceType", device_data.get("type", "unknown"))
             device_type = self._parse_device_type(raw_device_type)
 
-            # Skip smart locks in normal device flow (handled via smart-locks endpoint)
+            # Smart locks get their own entities (see _async_update_smart_locks),
+            # so they are skipped from the regular device flow — but this enriched
+            # hub-device record is the ONLY place the lock state (lockStatus /
+            # doorStatus) is exposed; the dedicated smart-locks endpoint returns
+            # just the id, and Yale-bridged locks emit no smartlock* events, so
+            # REST polling is their only state source (#88).
             if device_type == DeviceType.SMART_LOCK:
-                _LOGGER.debug(
-                    "Skipping smart lock %s in device flow (handled separately)",
-                    device_id,
-                )
+                self._apply_smart_lock_rest_state(space, device_id, device_data)
                 continue
 
             # Get room_id and room_name

--- a/tests/test_coordinator_devices_coverage.py
+++ b/tests/test_coordinator_devices_coverage.py
@@ -29,6 +29,7 @@ from custom_components.ajax.models import (
     AjaxAccount,
     AjaxDevice,
     AjaxRoom,
+    AjaxSmartLock,
     AjaxSpace,
     DeviceType,
 )
@@ -1253,3 +1254,60 @@ async def test_update_devices_removed_device_unregistered_from_ha() -> None:
     registry.async_get_device.assert_called_once_with(identifiers={device_identifier("entry_test", "ghost")})
     registry.async_remove_device.assert_called_once_with("ha-ghost")
     assert "ghost" not in space.devices
+
+
+# ---------------------------------------------------------------------------
+# _apply_smart_lock_rest_state (#88 — REST polling state for event-less locks)
+# ---------------------------------------------------------------------------
+
+
+def _lock_mixin() -> AjaxDevicesMixin:
+    return object.__new__(AjaxDevicesMixin)
+
+
+def test_apply_smart_lock_rest_state_from_record() -> None:
+    mixin = _lock_mixin()
+    space = _make_space()
+    lock = AjaxSmartLock(id="lock1", name="Doorman", space_id="s1")
+    space.smart_locks["lock1"] = lock
+    mixin._apply_smart_lock_rest_state(space, "lock1", {"lockStatus": "LOCKED", "doorStatus": "OPEN"})
+    assert lock.is_locked is True
+    assert lock.is_door_open is True
+    mixin._apply_smart_lock_rest_state(space, "lock1", {"lockStatus": "UNLOCKED", "doorStatus": "CLOSED"})
+    assert lock.is_locked is False
+    assert lock.is_door_open is False
+
+
+def test_apply_smart_lock_rest_state_missing_lock_is_noop() -> None:
+    # Lock not discovered yet → no entry, must not raise.
+    _lock_mixin()._apply_smart_lock_rest_state(_make_space(), "ghost", {"lockStatus": "LOCKED"})
+
+
+def test_apply_smart_lock_rest_state_ignores_unknown_status() -> None:
+    mixin = _lock_mixin()
+    space = _make_space()
+    lock = AjaxSmartLock(id="lock1", name="Doorman", space_id="s1")
+    space.smart_locks["lock1"] = lock
+    mixin._apply_smart_lock_rest_state(space, "lock1", {})
+    assert lock.is_locked is None  # nothing in the record → stays unknown
+
+
+def test_apply_smart_lock_rest_state_skips_recent_event() -> None:
+    """A real-time event within 30 s wins over the slower poll."""
+    mixin = _lock_mixin()
+    space = _make_space()
+    lock = AjaxSmartLock(id="lock1", name="Doorman", space_id="s1", is_locked=False)
+    lock.last_event_time = datetime.now(UTC)
+    space.smart_locks["lock1"] = lock
+    mixin._apply_smart_lock_rest_state(space, "lock1", {"lockStatus": "LOCKED"})
+    assert lock.is_locked is False  # event value preserved
+
+
+def test_apply_smart_lock_rest_state_applies_after_stale_event() -> None:
+    mixin = _lock_mixin()
+    space = _make_space()
+    lock = AjaxSmartLock(id="lock1", name="Doorman", space_id="s1", is_locked=False)
+    lock.last_event_time = datetime.now(UTC) - timedelta(minutes=5)
+    space.smart_locks["lock1"] = lock
+    mixin._apply_smart_lock_rest_state(space, "lock1", {"lockStatus": "LOCKED"})
+    assert lock.is_locked is True  # stale event → poll updates


### PR DESCRIPTION
## Summary

Makes smart-lock state work by **polling**, for locks that never emit `smartlock*` events — the exact case @EagleStClair hit in #88 with a Yale Doorman V2N behind a LockBridge.

## Root cause

Lock state had only two sources: the dedicated smart-locks endpoint (returns just the `id`) and real-time `smartlock*` SSE/SQS events. A bridged lock that emits no events leaves `is_locked` / `is_door_open` stuck on *unknown*.

But the device record @EagleStClair pasted shows the state **is** available in the enriched `hubs/{id}/devices` fetch:

```
"deviceType": "SmartLockYale",
"lockStatus": "UNLOCKED",
"doorStatus": "CLOSED",
```

The coordinator's device flow already fetches that record — it just **skipped smart locks entirely** and threw the state away.

## Change

- `_async_update_devices` now hands a smart-lock record to a new `_apply_smart_lock_rest_state` helper instead of discarding it. The helper reads `lockStatus` → `is_locked` and `doorStatus` → `is_door_open` on the discovered lock entity.
- A real-time event in the last 30 s still wins (events stay authoritative for locks that emit them; polling only fills the gap for those that don't).
- 5 unit tests cover the mapping, the missing-lock no-op, unknown statuses, and the event-recency guard.

## Verification

- `ruff` + `mypy --strict` clean; full suite green (1892 tests).
- Deployed to my HA dev instance: the device flow reconciled all 14 devices, `success: True`, 0 errors (no smart lock there to exercise the lock path, but no regression to device reconciliation).

Refs #88.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Smart-lock status now stays up to date even when real-time events are unavailable, using periodic polling as a fallback.
  * Door and lock state should remain accurate after reconnects or missed event updates.
  * Recent real-time updates still take priority, helping prevent older polled data from overwriting newer status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->