### PR TITLE
fix(lock): smart-lock icon now reflects state (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **The smart-lock icon now reflects the lock state (#88).** A static `mdi:lock` icon in `icons.json` overrode Home Assistant's native state-based lock icon, so the padlock always looked locked (only the colour changed). The icon now switches between locked and unlocked (`mdi:lock` / `mdi:lock-open-variant`).
+
 ## [0.33.3] - 2026-06-29
 
 ### Fixed

--- a/custom_components/ajax/icons.json
+++ b/custom_components/ajax/icons.json
@@ -66,7 +66,11 @@
     },
     "lock": {
       "smart_lock": {
-        "default": "mdi:lock"
+        "default": "mdi:lock",
+        "state": {
+          "locked": "mdi:lock",
+          "unlocked": "mdi:lock-open-variant"
+        }
       }
     },
     "number": {


### PR DESCRIPTION
Fixes the minor icon issue from #88 (confirmed by @EagleStClair after the v0.33.3 state fix).

A static `mdi:lock` default in `icons.json` overrode Home Assistant's native state-based lock icon, so the padlock always rendered as **locked** regardless of state — only the colour changed. Added a `state` mapping:

```json
"smart_lock": { "default": "mdi:lock", "state": { "locked": "mdi:lock", "unlocked": "mdi:lock-open-variant" } }
```

Now the padlock opens/closes with the lock state. Data-only change; full suite green (1892).

Refs #88.