### PR TITLE
fix(lock): show lock-question icon for unknown smart-lock state (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Smart lock showed a closed-padlock icon while its state was still unknown (#88).** Before the first poll/event the lock state is unknown, but the icon fell back to `mdi:lock` (a *locked* padlock), making the lock look locked. The unknown state now uses a distinct `mdi:lock-question` icon; the `locked` / `unlocked` icons are unchanged.
+
 ## [0.34.0] - 2026-06-29
 
 ### Added

--- a/custom_components/ajax/icons.json
+++ b/custom_components/ajax/icons.json
@@ -66,7 +66,7 @@
     },
     "lock": {
       "smart_lock": {
-        "default": "mdi:lock",
+        "default": "mdi:lock-question",
         "state": {
           "locked": "mdi:lock",
           "unlocked": "mdi:lock-open-variant"


### PR DESCRIPTION
## Summary

Fixes the misleading smart-lock icon reported in #88: a lock whose state isn't known yet (no poll/event received) showed a **closed padlock**, making it look locked.

## Cause

`icons.json` mapped the smart-lock `locked` / `unlocked` states, but the **`default`** (used for the *unknown* / *unavailable* state) was `mdi:lock` — a locked padlock. So before the first `lockStatus` poll or `smartlock*` event, the entity rendered as if locked.

## Change

```json
"smart_lock": {
  "default": "mdi:lock-question",            // was "mdi:lock"
  "state": { "locked": "mdi:lock", "unlocked": "mdi:lock-open-variant" }
}
```

Unknown state now shows `mdi:lock-question` (a padlock with a question mark); `locked` and `unlocked` are unchanged.

Refs #88.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Smart-lock entities now show a distinct “unknown” lock icon before the first status update, instead of appearing locked.
  * Existing locked and unlocked icons remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->