### PR TITLE
fix(sqs): retry SQS init so real-time events self-heal after a late aiobotocore install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Real-time SQS could stay off for the whole session after a slow start (intermittent "aiobotocore required").** If `aiobotocore` — which Home Assistant installs in the background — took longer than the ~3-minute startup window to land (more likely right after an update that also pulls a large dependency), SQS gave up permanently and only the slower REST polling ran until a manual restart. SQS now retries on later poll cycles and **self-heals automatically** once the dependency is installed.
+
 ## [0.34.1] - 2026-06-30
 
 ### Fixed

--- a/custom_components/ajax/_coordinator_init.py
+++ b/custom_components/ajax/_coordinator_init.py
@@ -89,6 +89,7 @@ class AjaxBootstrapMixin:
         _aws_secret_access_key: str | None
         _queue_name: str | None
         _sqs_initialized: bool
+        _sqs_init_in_progress: bool
         _sse_url: str | None
         _sse_initialized: bool
         _smart_lock_store: Store[Any]
@@ -206,6 +207,9 @@ class AjaxBootstrapMixin:
         Requires ``aiobotocore`` + AWS credentials. On failure the
         integration falls back to REST-only mode without raising.
         """
+        if self._sqs_init_in_progress:
+            return  # a startup/retry attempt is already running — don't overlap
+
         if not SQS_AVAILABLE:
             _LOGGER.info("AWS SQS not available (aiobotocore not installed). Using REST API polling only.")
             self._sqs_initialized = True  # Mark as "initialized" to prevent retries.
@@ -219,6 +223,7 @@ class AjaxBootstrapMixin:
         entry_id = self.config_entry.entry_id if self.config_entry else "unknown"
         sqs_issue = f"sqs_init_failed_{entry_id}"
 
+        self._sqs_init_in_progress = True
         try:
             _LOGGER.info("Initializing AWS SQS for real-time events...")
 
@@ -252,7 +257,8 @@ class AjaxBootstrapMixin:
 
             if sqs_client is None:
                 _LOGGER.warning(
-                    "aiobotocore unavailable after ~%d s — real-time SQS disabled, using REST API polling only",
+                    "aiobotocore unavailable after ~%d s — real-time SQS deferred, using REST API "
+                    "polling meanwhile; will retry automatically once the dependency is installed",
                     SQS_AIOBOTOCORE_WAIT_ATTEMPTS * SQS_AIOBOTOCORE_WAIT_INTERVAL,
                 )
                 ir.async_create_issue(
@@ -264,6 +270,9 @@ class AjaxBootstrapMixin:
                     translation_key="sqs_init_failed",
                     translation_placeholders={"error": "aiobotocore required"},
                 )
+                # Leave _sqs_initialized False (transient): a later poll retries
+                # via the periodic-update branch, so SQS self-heals without a
+                # manual restart once pip finishes installing aiobotocore.
                 return
 
             self.sqs_manager = _SQSManager(
@@ -280,10 +289,12 @@ class AjaxBootstrapMixin:
 
             if success:
                 _LOGGER.info("✓ AWS SQS initialized successfully - Real-time events enabled!")
+                self._sqs_initialized = True
                 ir.async_delete_issue(self.hass, DOMAIN, sqs_issue)
             else:
                 _LOGGER.warning("Failed to start SQS - Falling back to REST API polling only")
                 self.sqs_manager = None
+                self._sqs_initialized = True  # config/network failure — not the aiobotocore race
                 ir.async_create_issue(
                     self.hass,
                     DOMAIN,
@@ -300,6 +311,7 @@ class AjaxBootstrapMixin:
                 err,
             )
             self.sqs_manager = None
+            self._sqs_initialized = True  # unexpected error — don't retry in a loop
             ir.async_create_issue(
                 self.hass,
                 DOMAIN,
@@ -310,7 +322,7 @@ class AjaxBootstrapMixin:
                 translation_placeholders={"error": str(err)},
             )
         finally:
-            self._sqs_initialized = True
+            self._sqs_init_in_progress = False
 
     # ------------------------------------------------------------------
     # SSE (proxy mode)

--- a/custom_components/ajax/coordinator.py
+++ b/custom_components/ajax/coordinator.py
@@ -156,6 +156,7 @@ class AjaxDataCoordinator(
         self._aws_secret_access_key = aws_secret_access_key
         self._queue_name = queue_name
         self._sqs_initialized = False
+        self._sqs_init_in_progress = False
 
         # SSE real-time events (optional, for proxy mode)
         self.sse_manager: SSEManager | None = None
@@ -378,7 +379,7 @@ class AjaxDataCoordinator(
                     if not self._sse_initialized and self._sse_url:
                         # Proxy mode: use SSE for real-time events
                         entry.async_create_background_task(self.hass, self._async_init_sse(), "ajax_init_sse")
-                    elif not self._sqs_initialized and self._aws_access_key_id:
+                    elif not self._sqs_initialized and not self._sqs_init_in_progress and self._aws_access_key_id:
                         # Direct mode: use SQS for real-time events
                         entry.async_create_background_task(self.hass, self._async_init_sqs(), "ajax_init_sqs")
 
@@ -387,6 +388,18 @@ class AjaxDataCoordinator(
                         entry.async_create_background_task(self.hass, self._async_init_onvif(), "ajax_init_onvif")
             else:
                 # Periodic update - optimized polling
+                # Retry real-time SQS if it never came up in direct mode — e.g.
+                # aiobotocore was still being installed during initial load. This
+                # self-heals without a manual restart once the dependency lands.
+                if (
+                    self.config_entry is not None
+                    and self._aws_access_key_id
+                    and not self._sse_url
+                    and not self._sqs_initialized
+                    and not self._sqs_init_in_progress
+                ):
+                    self.config_entry.async_create_background_task(self.hass, self._async_init_sqs(), "ajax_retry_sqs")
+
                 # Check if we need full metadata refresh (hourly or forced)
                 need_metadata_refresh = self._force_metadata_refresh or self._should_refresh_metadata()
                 if need_metadata_refresh:

--- a/tests/test_coordinator_core_coverage.py
+++ b/tests/test_coordinator_core_coverage.py
@@ -79,6 +79,9 @@ def _coordinator() -> AjaxDataCoordinator:
     coord._door_sensor_poll_security_state = SecurityState.DISARMED
     coord._door_sensor_fast_poll_enabled = False
     coord._sse_url = None
+    coord._sqs_initialized = False
+    coord._sqs_init_in_progress = False
+    coord._aws_access_key_id = None
 
     # Auth resilience.
     coord._consecutive_auth_errors = 0

--- a/tests/test_coordinator_state_coverage.py
+++ b/tests/test_coordinator_state_coverage.py
@@ -469,7 +469,9 @@ async def test_update_notifications_no_account_and_unknown_space() -> None:
 
 
 def _bootstrap() -> AjaxBootstrapMixin:
-    return object.__new__(AjaxBootstrapMixin)
+    mixin = object.__new__(AjaxBootstrapMixin)
+    mixin._sqs_init_in_progress = False
+    return mixin
 
 
 @pytest.mark.asyncio
@@ -767,7 +769,23 @@ async def test_init_sqs_aiobotocore_never_installs_creates_issue() -> None:
     ir_mod.async_create_issue.assert_called_once()
     # Surfaced with the dependency-missing reason.
     assert ir_mod.async_create_issue.call_args.kwargs["translation_placeholders"]["error"] == "aiobotocore required"
-    assert mixin._sqs_initialized is True
+    # Left False on the transient aiobotocore race so a later poll retries — SQS
+    # self-heals once pip finishes installing the dependency (no manual restart).
+    assert mixin._sqs_initialized is False
+    assert mixin._sqs_init_in_progress is False  # guard released by the finally
+
+
+@pytest.mark.asyncio
+async def test_init_sqs_skips_when_already_in_progress() -> None:
+    """A concurrent poll must not start a second SQS init while one is running."""
+    mixin = _bootstrap()
+    mixin._sqs_init_in_progress = True
+    mixin._sqs_initialized = False
+    mixin._aws_access_key_id = "AKIA"
+    with patch.object(init_mod, "_AjaxSQSClient") as client_factory:
+        await mixin._async_init_sqs()
+    client_factory.assert_not_called()  # guarded out before building anything
+    assert mixin._sqs_initialized is False  # untouched — a later poll retries
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Some users intermittently see this and never get real-time events until they manually restart:

> The Ajax integration couldn't connect to AWS SQS — real-time event notifications are disabled and the integration falls back to REST polling (slower). **Error: aiobotocore required**

`aiobotocore` is installed in the background by Home Assistant. `_async_init_sqs` waits out a ~3-minute window for it, but if pip is slow — **more likely now that a large dependency like `onvif-zeep-async` competes for the install slot after an update** — the window is exceeded. The old `finally: self._sqs_initialized = True` then **permanently disabled retries**, so SQS stayed off for the whole session even though aiobotocore landed seconds later.

## Fix

- The **transient aiobotocore path** now leaves `_sqs_initialized` `False`, and the **periodic-update branch retries** `_async_init_sqs` on later polls — so SQS **self-heals** once the dependency is installed, no manual restart.
- A new `_sqs_init_in_progress` guard prevents overlapping retries while an attempt (including the ~3-minute window) is running.
- **Genuine** failures (bad credentials, manager start error, unexpected exception) stay terminal — no retry loop.

## Verification

- `ruff` + `mypy --strict` clean; full suite green (**1896 tests**, incl. updated + new tests: the aiobotocore-never-installs case now asserts `_sqs_initialized is False`, plus a guard-against-overlap test).
- Deployed to my HA dev instance (direct/SQS mode): the normal path is unaffected — `✓ AWS SQS initialized successfully`, 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Real-time SQS now retries automatically if it wasn’t available during startup, instead of staying disabled for the rest of the session.
  * Slow optional dependency installs no longer block future SQS recovery; the app continues polling and can self-heal once ready.
  * Duplicate SQS startup attempts are prevented, improving stability during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->