### PR TITLE
fix(config): reschedule reauth/reconfigure reload when entry has no listener

### DIFF
--- a/custom_components/ajax/__init__.py
+++ b/custom_components/ajax/__init__.py
@@ -36,6 +36,7 @@ from .const import (
     CONF_AUTH_MODE,
     CONF_AWS_ACCESS_KEY_ID,
     CONF_AWS_SECRET_ACCESS_KEY,
+    CONF_DISCOVERED_MACS,
     CONF_DOOR_SENSOR_FAST_POLL,
     CONF_EMAIL,
     CONF_ENABLED_SPACES,
@@ -239,15 +240,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxConfigEntry) -> bool
 def _reload_relevant_config(entry: AjaxConfigEntry) -> tuple[dict[str, Any], str, str]:
     """Return the part of the entry config that requires a reload to apply.
 
-    ``entry.data`` only holds connection/credential settings (auth mode,
-    email/password, API key, proxy, AWS SQS, enabled spaces, discovered
-    MACs). In ``entry.options`` only the RTSP/ONVIF credentials need a
+    ``entry.data`` mostly holds connection/credential settings (auth mode,
+    email/password, API key, proxy, AWS SQS, enabled spaces) that do need a
+    reload to take effect. ``CONF_DISCOVERED_MACS`` is excluded: it only
+    tracks which DHCP-discovered hubs have been associated with this entry
+    for deduplication in the config flow and has no runtime effect, so
+    changing it (e.g. associating a newly discovered hub) must not trigger a
+    reload. In ``entry.options`` only the RTSP/ONVIF credentials need a
     reload — the ONVIF manager reads them at bootstrap only; everything
     else is either applied live (fast poll) or read dynamically
     (notification settings).
     """
+    data = {k: v for k, v in entry.data.items() if k != CONF_DISCOVERED_MACS}
     return (
-        dict(entry.data),
+        data,
         entry.options.get(CONF_RTSP_USERNAME, ""),
         entry.options.get(CONF_RTSP_PASSWORD, ""),
     )

--- a/custom_components/ajax/config_flow.py
+++ b/custom_components/ajax/config_flow.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant.config_entries import (
+    ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
     OptionsFlow,
@@ -456,8 +457,15 @@ class AjaxConfigFlow(ConfigFlow, domain=DOMAIN):
                         # listener schedules the reload (HA deprecates the
                         # flow-side reload helper on entries with a listener).
                         # Same password (expired-token case) → the listener
-                        # will not fire, so retry the setup explicitly.
-                        if reauth_entry.data.get(CONF_PASSWORD) == password_hash:
+                        # will not fire, so retry the setup explicitly. Same
+                        # if the entry isn't loaded (setup failed before the
+                        # listener could be registered, e.g. a previous
+                        # ConfigEntryAuthFailed) — there is no listener to
+                        # rely on, so the flow must reschedule the setup.
+                        if (
+                            reauth_entry.data.get(CONF_PASSWORD) == password_hash
+                            or reauth_entry.state is not ConfigEntryState.LOADED
+                        ):
                             self.hass.config_entries.async_schedule_reload(reauth_entry.entry_id)
                         return self.async_update_and_abort(
                             reauth_entry,
@@ -677,8 +685,14 @@ class AjaxConfigFlow(ConfigFlow, domain=DOMAIN):
                 # schedules the reload (HA deprecates the flow-side reload
                 # helper on entries with a listener). Same password
                 # (expired-token case) → the listener will not fire, so
-                # retry the setup explicitly.
-                if reauth_entry.data.get(CONF_PASSWORD) == password_hash:
+                # retry the setup explicitly. Same if the entry isn't loaded
+                # (setup failed before the listener could be registered,
+                # e.g. a previous ConfigEntryAuthFailed) — there is no
+                # listener to rely on, so the flow must reschedule the setup.
+                if (
+                    reauth_entry.data.get(CONF_PASSWORD) == password_hash
+                    or reauth_entry.state is not ConfigEntryState.LOADED
+                ):
                     self.hass.config_entries.async_schedule_reload(reauth_entry.entry_id)
                 return self.async_update_and_abort(
                     reauth_entry,
@@ -767,7 +781,10 @@ class AjaxConfigFlow(ConfigFlow, domain=DOMAIN):
 
                 # The update listener schedules the reload on data change;
                 # identical resubmission still retries the setup explicitly.
-                if new_data == dict(reconfigure_entry.data):
+                # Same if the entry isn't loaded (setup failed before the
+                # listener could be registered) — there is no listener to
+                # rely on, so the flow must reschedule the setup itself.
+                if new_data == dict(reconfigure_entry.data) or reconfigure_entry.state is not ConfigEntryState.LOADED:
                     self.hass.config_entries.async_schedule_reload(reconfigure_entry.entry_id)
                 return self.async_update_and_abort(
                     reconfigure_entry,

--- a/tests/test_config_flow_coverage.py
+++ b/tests/test_config_flow_coverage.py
@@ -15,6 +15,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.config_entries import ConfigEntryState
 
 from custom_components.ajax.api import (
     AjaxRest2FARequiredError,
@@ -583,6 +584,7 @@ async def test_step_2fa_reauth_success() -> None:
     reauth_entry = MagicMock()
     reauth_entry.data = {CONF_EMAIL: "u@e.com"}
     reauth_entry.entry_id = "entry-1"
+    reauth_entry.state = ConfigEntryState.LOADED
     flow.hass.config_entries.async_get_entry = MagicMock(return_value=reauth_entry)
     flow.hass.config_entries.async_update_entry = MagicMock()
     flow.hass.config_entries.async_schedule_reload = MagicMock()
@@ -593,6 +595,37 @@ async def test_step_2fa_reauth_success() -> None:
     # async_update_and_abort → update only; the update listener owns the reload.
     flow.hass.config_entries.async_update_entry.assert_called_once()
     flow.hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+async def test_step_2fa_reauth_not_loaded_schedules_reload() -> None:
+    """2FA reauth on an entry that isn't LOADED must reschedule the setup itself.
+
+    Mirrors ``test_step_reauth_confirm_changed_password_not_loaded_schedules_reload``
+    for the 2FA branch of the reauth flow.
+    """
+    flow = _make_flow(source="reauth")
+    flow.context["entry_id"] = "entry-1"
+    flow._api = _mock_api(hubs=[])
+    flow._request_id = "rid"
+    flow._user_input = {
+        CONF_AUTH_MODE: AUTH_MODE_DIRECT,
+        CONF_API_KEY: "key",
+        CONF_EMAIL: "u@e.com",
+        CONF_PASSWORD: "secret",
+    }
+    reauth_entry = MagicMock()
+    reauth_entry.data = {CONF_EMAIL: "u@e.com"}
+    reauth_entry.entry_id = "entry-1"
+    reauth_entry.state = ConfigEntryState.SETUP_ERROR
+    flow.hass.config_entries.async_get_entry = MagicMock(return_value=reauth_entry)
+    flow.hass.config_entries.async_update_entry = MagicMock()
+    flow.hass.config_entries.async_schedule_reload = MagicMock()
+
+    result = await flow.async_step_2fa({"code": "123456"})
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_successful"
+    flow.hass.config_entries.async_update_entry.assert_called_once()
+    flow.hass.config_entries.async_schedule_reload.assert_called_once_with("entry-1")
 
 
 async def test_step_2fa_invalid_code() -> None:
@@ -801,6 +834,7 @@ async def test_step_reauth_confirm_direct_success() -> None:
     flow.context["entry_id"] = "e1"
     entry = MagicMock()
     entry.entry_id = "e1"
+    entry.state = ConfigEntryState.LOADED
     entry.data = {CONF_EMAIL: "u@e.com", CONF_AUTH_MODE: AUTH_MODE_DIRECT, CONF_API_KEY: "key"}
     flow.hass.config_entries.async_get_entry = MagicMock(return_value=entry)
     flow.hass.config_entries.async_update_entry = MagicMock()
@@ -841,6 +875,61 @@ async def test_step_reauth_confirm_same_password_schedules_reload() -> None:
     assert result["type"] == "abort"
     assert result["reason"] == "reauth_successful"
     flow.hass.config_entries.async_schedule_reload.assert_called_once_with("e1")
+
+
+async def test_step_reauth_confirm_changed_password_not_loaded_schedules_reload() -> None:
+    """A changed password on an entry that isn't LOADED must reschedule the setup.
+
+    An entry that failed setup (e.g. ConfigEntryAuthFailed on a stale
+    password) never reaches the point where the update listener is
+    registered, so nothing would ever reload it once reauth succeeds unless
+    the flow schedules the reload itself.
+    """
+    flow = _make_flow()
+    flow.context["entry_id"] = "e1"
+    entry = MagicMock()
+    entry.entry_id = "e1"
+    entry.state = ConfigEntryState.SETUP_ERROR
+    entry.data = {
+        CONF_EMAIL: "u@e.com",
+        CONF_AUTH_MODE: AUTH_MODE_DIRECT,
+        CONF_API_KEY: "key",
+        CONF_PASSWORD: "oldhash",
+    }
+    flow.hass.config_entries.async_get_entry = MagicMock(return_value=entry)
+    flow.hass.config_entries.async_update_entry = MagicMock()
+    flow.hass.config_entries.async_schedule_reload = MagicMock()
+    api = _mock_api()
+    with patch(API_PATH, return_value=api):
+        result = await flow.async_step_reauth_confirm({CONF_PASSWORD: "newpass"})
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_successful"
+    flow.hass.config_entries.async_schedule_reload.assert_called_once_with("e1")
+    flow.hass.config_entries.async_update_entry.assert_called_once()
+
+
+async def test_step_reauth_confirm_changed_password_loaded_no_reload() -> None:
+    """A changed password on a LOADED entry lets the update listener reload it."""
+    flow = _make_flow()
+    flow.context["entry_id"] = "e1"
+    entry = MagicMock()
+    entry.entry_id = "e1"
+    entry.state = ConfigEntryState.LOADED
+    entry.data = {
+        CONF_EMAIL: "u@e.com",
+        CONF_AUTH_MODE: AUTH_MODE_DIRECT,
+        CONF_API_KEY: "key",
+        CONF_PASSWORD: "oldhash",
+    }
+    flow.hass.config_entries.async_get_entry = MagicMock(return_value=entry)
+    flow.hass.config_entries.async_update_entry = MagicMock()
+    flow.hass.config_entries.async_schedule_reload = MagicMock()
+    api = _mock_api()
+    with patch(API_PATH, return_value=api):
+        result = await flow.async_step_reauth_confirm({CONF_PASSWORD: "newpass"})
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_successful"
+    flow.hass.config_entries.async_schedule_reload.assert_not_called()
 
 
 async def test_step_reauth_confirm_proxy_success() -> None:
@@ -921,11 +1010,14 @@ async def test_step_reauth_confirm_unknown_exception() -> None:
 # --------------------------------------------------------------------------- #
 # async_step_reconfigure
 # --------------------------------------------------------------------------- #
-def _reconfigure_flow(entry_data: dict[str, Any]) -> AjaxConfigFlow:
+def _reconfigure_flow(
+    entry_data: dict[str, Any], *, state: ConfigEntryState = ConfigEntryState.LOADED
+) -> AjaxConfigFlow:
     flow = _make_flow()
     entry = MagicMock()
     entry.entry_id = "e1"
     entry.data = entry_data
+    entry.state = state
     flow._get_reconfigure_entry = MagicMock(return_value=entry)
     flow.async_update_and_abort = MagicMock(
         side_effect=lambda *a, **kw: {
@@ -989,6 +1081,43 @@ async def test_step_reconfigure_proxy_success_strips_url() -> None:
     assert result["reason"] == "reconfigure_successful"
     assert result["data"][CONF_PROXY_URL] == "https://new"
     assert result["data"][CONF_VERIFY_SSL] is False
+
+
+async def test_step_reconfigure_changed_data_not_loaded_schedules_reload() -> None:
+    """Changed data on an entry that isn't LOADED must reschedule the setup.
+
+    Mirrors ``test_step_reauth_confirm_changed_password_not_loaded_schedules_reload``:
+    an entry stuck in SETUP_ERROR never registered an update listener, so the
+    flow must schedule the reload itself once reconfigure succeeds.
+    """
+    flow = _reconfigure_flow(
+        {CONF_AUTH_MODE: AUTH_MODE_DIRECT, CONF_API_KEY: "oldkey", CONF_EMAIL: "old@e.com"},
+        state=ConfigEntryState.SETUP_ERROR,
+    )
+    api = _mock_api()
+    with patch(API_PATH, return_value=api):
+        result = await flow.async_step_reconfigure(
+            {CONF_API_KEY: "newkey", CONF_EMAIL: "new@e.com", CONF_PASSWORD: "newpass"}
+        )
+    assert result["type"] == "abort"
+    assert result["reason"] == "reconfigure_successful"
+    flow.hass.config_entries.async_schedule_reload.assert_called_once_with("e1")
+
+
+async def test_step_reconfigure_changed_data_loaded_no_reload() -> None:
+    """Changed data on a LOADED entry lets the update listener reload it."""
+    flow = _reconfigure_flow(
+        {CONF_AUTH_MODE: AUTH_MODE_DIRECT, CONF_API_KEY: "oldkey", CONF_EMAIL: "old@e.com"},
+        state=ConfigEntryState.LOADED,
+    )
+    api = _mock_api()
+    with patch(API_PATH, return_value=api):
+        result = await flow.async_step_reconfigure(
+            {CONF_API_KEY: "newkey", CONF_EMAIL: "new@e.com", CONF_PASSWORD: "newpass"}
+        )
+    assert result["type"] == "abort"
+    assert result["reason"] == "reconfigure_successful"
+    flow.hass.config_entries.async_schedule_reload.assert_not_called()
 
 
 async def test_step_reconfigure_auth_error() -> None:

--- a/tests/test_init_coverage.py
+++ b/tests/test_init_coverage.py
@@ -30,10 +30,12 @@ from custom_components.ajax import (
     _async_setup_areas,
     _async_setup_services,
     _async_update_options,
+    _reload_relevant_config,
     async_remove_config_entry_device,
     async_setup,
     async_unload_entry,
 )
+from custom_components.ajax.const import CONF_DISCOVERED_MACS, CONF_PASSWORD
 from custom_components.ajax.models import SecurityState
 
 
@@ -1038,6 +1040,45 @@ async def test_update_options_rtsp_change_schedules_reload() -> None:
     coord = MagicMock()
     coord._reload_config_snapshot = _synced_snapshot()
     entry.runtime_data = coord
+
+    await _async_update_options(hass, entry)
+
+    hass.config_entries.async_schedule_reload.assert_called_once_with("e1")
+
+
+async def test_update_options_discovered_macs_change_no_reload() -> None:
+    """Associating a DHCP-discovered hub (CONF_DISCOVERED_MACS) must not reload.
+
+    The key only feeds config-flow dedup for discovery and has no runtime
+    effect, so ``_reload_relevant_config`` excludes it from the snapshot.
+    """
+    entry = _options_entry(fast_poll=False)
+    entry.data = {CONF_DISCOVERED_MACS: ["AA:BB:CC:DD:EE:FF"]}
+    coord = MagicMock()
+    coord._reload_config_snapshot = _reload_relevant_config(entry)
+    coord._door_sensor_fast_poll_enabled = False
+    coord._manage_door_sensor_polling = MagicMock()
+    entry.runtime_data = coord
+
+    # Associate a second discovered hub — only CONF_DISCOVERED_MACS changes.
+    entry.data = {CONF_DISCOVERED_MACS: ["AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66"]}
+    hass = MagicMock()
+
+    await _async_update_options(hass, entry)
+
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+async def test_update_options_password_change_schedules_reload() -> None:
+    """A changed CONF_PASSWORD is connection-relevant and must schedule a reload."""
+    entry = _options_entry(fast_poll=False)
+    entry.data = {CONF_PASSWORD: "oldhash"}
+    coord = MagicMock()
+    coord._reload_config_snapshot = _reload_relevant_config(entry)
+    entry.runtime_data = coord
+
+    entry.data = {CONF_PASSWORD: "newhash"}
+    hass = MagicMock()
 
     await _async_update_options(hass, entry)
 


### PR DESCRIPTION
## Problem

The listener-owned reload architecture (85d8e46f) left one path dead: the update listener is only registered at the **end** of a successful `async_setup_entry`. When setup fails with `ConfigEntryAuthFailed` (typical case: the Ajax account password changed while HA was down), the entry sits in `SETUP_ERROR` with **no listener**. The user then completes reauth with the new, correct password — the flow writes the data and relies on the listener to reload… which doesn't exist. The entry stays dead until a manual reload or restart. HA core does not reload an entry after a reauth flow on its own, so this was the most common reauth scenario silently failing to recover.

A second, smaller defect in the same snapshot logic: `_reload_relevant_config` included `CONF_DISCOVERED_MACS`, so associating a DHCP-discovered hub with a loaded entry triggered a full reload (re-login, SSE/SQS teardown, brief entity unavailability) for a key that has zero runtime effect.

## Fix

- All three flow sites (reauth 2FA, `reauth_confirm`, reconfigure) now also schedule the reload explicitly when `entry.state is not ConfigEntryState.LOADED` — a not-loaded entry has no listener to rely on. When the entry IS loaded, behavior is unchanged: the listener owns the reload, so this stays compliant with the HA 2026.6 deprecation (error in 2026.12) on flow-side reload helpers.
- `_reload_relevant_config` excludes `CONF_DISCOVERED_MACS` from the snapshot, so DHCP association no longer counts as a connection-relevant change.

## Tests

7 new tests: both directions (schedules reload / defers to listener) for reauth_confirm, 2FA and reconfigure with explicit `ConfigEntryState`, plus listener tests proving a MACs-only data change does not reload while a password change does. Existing reauth/reconfigure tests now set `entry.state` explicitly (bare MagicMock `.state` would silently hit the new branch).

## Verification

- `mypy custom_components/ajax/` → 0 errors (strict)
- `ruff check` + `ruff format --check` → clean
- `python -m pytest tests/ --cov=custom_components/ajax` → **1939 passed, 99% coverage**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary reloads when discovered hub MAC addresses change.
  * Improved reauthentication and reconfiguration handling so setup retries correctly when an entry isn’t fully loaded.
  * Ensured password changes still trigger the expected reload behavior.
* **Tests**
  * Expanded coverage for reload behavior across reauth, 2FA, and reconfigure flows.
  * Added checks for loaded vs. not-loaded entry states and for discovered MAC updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->