### PR TITLE
fix(hacs): raise minimum Home Assistant to 2025.11.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,6 @@
   "name": "Ajax Security System",
   "content_in_root": false,
   "render_readme": true,
-  "homeassistant": "2024.11.0",
+  "homeassistant": "2025.11.0",
   "zip_release": false
 }


### PR DESCRIPTION
## Problem

`hacs.json` declared `"homeassistant": "2024.11.0"`, but the code module-imports APIs that do not exist in HA of that era. On any HA between the declared floor and the real one, HACS allows the install but loading the config flow raises `ModuleNotFoundError` — the integration cannot be added, and DHCP discovery (declared in `manifest.json`) breaks too.

## Introduction versions (verified per-tag against home-assistant/core, not guessed)

| Symbol | First HA version |
|---|---|
| `homeassistant.helpers.service_info.dhcp` (`config_flow.py:22`) | **2025.2.0** (404 on 2024.11.0 / 2024.12.0 / 2025.1.x) |
| `ConfigFlow.async_update_and_abort` — entry-level variant used by the reauth/reconfigure flows | **2025.11.0** (only the `ConfigSubentryFlow` variant existed before; verified by class context, 1 → 2 occurrences of the method between 2025.10.4 and 2025.11.0) |
| `AlarmControlPanelState` | 2024.11.0 (not limiting) |
| `ConfigEntries.async_schedule_reload`, `ConfigFlow._get_reconfigure_entry`, `ConfigEntry.runtime_data` | ≤ 2024.11.0 (not limiting) |

Floor = max of the above = **2025.11.0**.

## Notes

- Metadata-only change; installs on older HA were already broken at config-flow import, this makes HACS say so upfront.
- CI always tests against the latest HA, so it cannot catch floor violations — worth keeping in mind when adopting freshly-released HA helpers (that is exactly how the `async_update_and_abort` requirement slipped in).
- README states no minimum HA version, so no doc change was needed.

## Verification

- `python -c "import json; json.load(open('hacs.json'))"` → valid
- `python -m pytest tests/ -q` → **1932 passed**