### PR TITLE
perf(api): skip per-lock detail fetch for known smart locks

### DIFF
--- a/custom_components/ajax/_coordinator_state.py
+++ b/custom_components/ajax/_coordinator_state.py
@@ -261,7 +261,9 @@ class AjaxStateUpdaterMixin:
             return
 
         try:
-            smart_locks_data = await self.api.async_get_smart_locks(space.real_space_id)
+            smart_locks_data = await self.api.async_get_smart_locks(
+                space.real_space_id, known_ids=set(space.smart_locks)
+            )
             _LOGGER.debug(
                 "Found %d smart lock(s) for space %s",
                 len(smart_locks_data),

--- a/custom_components/ajax/api/_video.py
+++ b/custom_components/ajax/api/_video.py
@@ -108,18 +108,28 @@ class _VideoMixin(AjaxRestClientBase):
             f"user/{self.user_id}/spaces/{space_id}/devices/video-edges/{video_edge_id}/rtsp",
         )
 
-    async def async_get_smart_locks(self, space_id: str) -> list[dict[str, Any]]:
+    async def async_get_smart_locks(self, space_id: str, known_ids: set[str] | None = None) -> list[dict[str, Any]]:
         """Get all smart lock devices for a space.
 
         Smart locks are discovered from the space's devices array
-        with type "SMART_LOCK", then fetched individually.
+        with type "SMART_LOCK". Only *unknown* ids (not in ``known_ids``)
+        are fetched individually via the per-lock detail endpoint — that
+        endpoint returns just the id (occasionally a name), which is only
+        useful the first time a lock is seen, to feed the Yale-cloud
+        discovery filter. Once a lock is known, its real state
+        (lockStatus/doorStatus) is read from the enriched devices payload
+        fetched on the same tick (see ``_coordinator_devices.py``), so the
+        space device entry is returned as-is instead of re-fetching detail.
 
         Args:
             space_id: Space ID (real_space_id from spaceBinding)
+            known_ids: Ids of smart locks already discovered; their detail
+                fetch is skipped and the space device entry is used instead.
 
         Returns:
             List of smart lock dictionaries
         """
+        known_ids = known_ids or set()
         space_data = await self.async_get_space(space_id)
         devices = space_data.get("devices", [])
         _LOGGER.debug(
@@ -132,6 +142,11 @@ class _VideoMixin(AjaxRestClientBase):
             if device.get("type") == "SMART_LOCK":
                 smart_lock_id = device.get("id")
                 if smart_lock_id:
+                    if smart_lock_id in known_ids:
+                        # Already discovered: the detail endpoint would add
+                        # nothing (see docstring) — reuse the space entry.
+                        smart_locks.append(device)
+                        continue
                     try:
                         smart_lock = await self.async_get_smart_lock(space_id, smart_lock_id)
                         # Merge name from space device listing if detail endpoint lacks it

--- a/tests/test_api_devices_coverage.py
+++ b/tests/test_api_devices_coverage.py
@@ -316,6 +316,65 @@ async def test_async_get_smart_locks_skips_device_without_id() -> None:
     assert result == []
 
 
+@pytest.mark.asyncio
+async def test_async_get_smart_locks_known_id_skips_detail_fetch() -> None:
+    """A lock already known (known_ids) must not trigger the per-lock detail GET.
+
+    The detail endpoint only returns the id (occasionally a name) — useful
+    once, at discovery, to feed the Yale-cloud filter. For an already-known
+    lock, its real state comes from the enriched devices payload fetched on
+    the same tick, so the space device entry is reused as-is.
+    """
+    api = _api()
+    space_device = {"id": "lock1", "type": "SMART_LOCK", "name": "Front"}
+    api._request.return_value = {"devices": [space_device]}
+
+    result = await api.async_get_smart_locks("space1", known_ids={"lock1"})
+
+    assert result == [space_device]
+    # Only the space GET happened; no detail GET for the known lock.
+    api._request.assert_awaited_once_with("GET", "user/USER123/spaces/space1")
+
+
+@pytest.mark.asyncio
+async def test_async_get_smart_locks_unknown_id_still_fetches_detail() -> None:
+    """An id absent from known_ids preserves discovery behavior (detail GET)."""
+    api = _api()
+
+    async def fake_request(method: str, endpoint: str, *args: object) -> object:
+        if endpoint == "user/USER123/spaces/space1":
+            return {"devices": [{"id": "lock1", "type": "SMART_LOCK", "name": "Door"}]}
+        return {"id": "lock1", "name": "Detailed"}
+
+    api._request.side_effect = fake_request
+    result = await api.async_get_smart_locks("space1", known_ids=set())
+
+    assert len(result) == 1
+    assert result[0]["name"] == "Detailed"
+    assert api._request.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_get_smart_locks_mixed_known_and_unknown() -> None:
+    """Known locks reuse the space entry; unknown ones still get a single detail GET."""
+    api = _api()
+    known_device = {"id": "lock-known", "type": "SMART_LOCK", "name": "Known"}
+    unknown_device = {"id": "lock-unknown", "type": "SMART_LOCK", "name": "Unknown"}
+
+    async def fake_request(method: str, endpoint: str, *args: object) -> object:
+        if endpoint == "user/USER123/spaces/space1":
+            return {"devices": [known_device, unknown_device]}
+        return {"id": "lock-unknown", "name": "Detailed"}
+
+    api._request.side_effect = fake_request
+    result = await api.async_get_smart_locks("space1", known_ids={"lock-known"})
+
+    assert known_device in result
+    assert any(sl.get("name") == "Detailed" for sl in result)
+    # 1 space GET + exactly 1 detail GET (for the unknown lock only).
+    assert api._request.await_count == 2
+
+
 # ---------------------------------------------------------------------------
 # Automation endpoints
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator_state_coverage.py
+++ b/tests/test_coordinator_state_coverage.py
@@ -362,6 +362,25 @@ async def test_smart_locks_update_existing_keeps_name_when_absent() -> None:
 
 
 @pytest.mark.asyncio
+async def test_smart_locks_passes_known_ids_to_api() -> None:
+    """The coordinator must pass already-discovered lock ids so the API layer
+    can skip their per-lock detail GET (perf: avoids one GET per known lock
+    on every video/smart cycle, see api/_video.py::async_get_smart_locks).
+    """
+    space = AjaxSpace(id="s1", name="Maison", real_space_id="real1")
+    space.smart_locks["lock1"] = AjaxSmartLock(id="lock1", name="Old", space_id="s1")
+    space.smart_locks["sse_lock"] = AjaxSmartLock(id="sse_lock", name="SSE", space_id="s1")
+    mixin = _ve_mixin(space)
+    mixin.api.async_get_smart_locks = AsyncMock(return_value=[{"id": "lock1", "name": "Renamed", "type": "smartlock"}])
+
+    await mixin._async_update_smart_locks("s1")
+
+    mixin.api.async_get_smart_locks.assert_awaited_once_with("real1", known_ids={"lock1", "sse_lock"})
+    # Existing lock updated from the (now detail-skipped) space entry.
+    assert space.smart_locks["lock1"].name == "Renamed"
+
+
+@pytest.mark.asyncio
 async def test_smart_locks_cleanup_removes_api_lock_preserves_sse_lock() -> None:
     space = AjaxSpace(id="s1", name="Maison", real_space_id="real1")
     # API-discovered lock that will disappear (has raw_data) -> removed.


### PR DESCRIPTION
## Problem

Every video/smart coordinator cycle called `GET .../smart-locks/{id}` for **each** smart lock — while the code itself documents (`_coordinator_devices.py`) that this endpoint "returns just the id" and the real lock state (`lockStatus`/`doorStatus`) is read from the enriched devices payload already fetched on the same tick (`_apply_smart_lock_rest_state`, #88). After initial discovery, that per-lock detail GET delivered nothing the tick didn't already have: for L locks, L wasted API calls per cycle. This is part of the API-budget reduction requested by the proxy maintainer (~200 req/min for 15 users).

## Fix

`async_get_smart_locks` gains a `known_ids: set[str] | None` parameter. For a lock already discovered, the space device entry is returned as-is (the exact path the error fallback already exercised in production) — no detail GET. Unknown ids keep the detail fetch, which feeds the Yale-cloud discovery filter. The coordinator passes `known_ids=set(space.smart_locks)`.

Yale cloud locks are never added to `space.smart_locks` (skipped at discovery by design), so they intentionally keep the per-cycle detail fetch that powers the filter.

## Tests

4 new tests: known id → zero detail GET (call-count asserted), unknown id → discovery fetch preserved, mixed known/unknown → exactly one detail GET, and the coordinator passing known ids while an existing lock still picks up a rename from the space entry.

## Verification

- `mypy custom_components/ajax/` → 0 errors (strict)
- `ruff check` + `ruff format --check` → clean
- `python -m pytest tests/ --cov=custom_components/ajax` → **1936 passed, 99% coverage** (`api/_video.py` at 100%)