### PR TITLE
perf(coordinator): light immediate refresh after realtime security events

### DIFF
--- a/custom_components/ajax/coordinator.py
+++ b/custom_components/ajax/coordinator.py
@@ -300,6 +300,18 @@ class AjaxDataCoordinator(
         self._force_metadata_refresh = True  # Set flag to force refresh
         await self.async_refresh()
 
+    async def async_force_state_refresh(self) -> None:
+        """Immediate light refresh after a realtime security event.
+
+        Bypasses the DataUpdateCoordinator debouncer (async_refresh, same
+        rationale as async_force_metadata_refresh) WITHOUT forcing the
+        account-wide metadata pass: hub state and per-group states are
+        fetched on every tick anyway (#150), so an arm/disarm event only
+        needs immediacy - not rooms/users/video re-fetches across all hubs.
+        """
+        _LOGGER.info("Forcing light state refresh (immediate)")
+        await self.async_refresh()
+
     async def async_request_refresh_bypass_cache(self) -> None:
         """Request a refresh that bypasses the proxy cache.
 

--- a/custom_components/ajax/sqs_manager.py
+++ b/custom_components/ajax/sqs_manager.py
@@ -449,8 +449,8 @@ class SQSManager(EventHandlerMixin):
             ha_action_pending,
         )
 
-        # Group arm/disarm events need a FULL refresh to update group states
-        # because the final state depends on how many groups are armed
+        # Group arm/disarm events need an immediate refresh to update group
+        # states (group states are already fetched on every tick, #150)
         is_group_event = event_tag in GROUP_ARM_EVENT_TAGS
 
         # Full arm/disarm also affects all groups - need refresh to update them
@@ -474,10 +474,17 @@ class SQSManager(EventHandlerMixin):
                     # Wait for Ajax backend to process the change before refreshing
                     # Without this delay, the API may return stale state
                     await asyncio.sleep(1.0)
-                    await self.coordinator.async_force_metadata_refresh()
-                    _LOGGER.info("SQS: Metadata refresh completed after security event")
+                    # Bypass proxy cache to get fresh group states from Ajax API
+                    # (parity with the SSE path)
+                    self.coordinator._bypass_cache_next_refresh = True
+                    # Group states are already fetched on every tick (#150), so an
+                    # arm/disarm event only needs an immediate light refresh - not a
+                    # full account-wide metadata pass (rooms/users/video re-fetches
+                    # across all hubs).
+                    await self.coordinator.async_force_state_refresh()
+                    _LOGGER.info("SQS: State refresh completed after security event")
                 except Exception as err:
-                    _LOGGER.error("SQS: Metadata refresh failed after security event: %s", err)
+                    _LOGGER.error("SQS: State refresh failed after security event: %s", err)
                 finally:
                     # Always clear the per-hub skip flag
                     if space.hub_id:

--- a/custom_components/ajax/sse_manager.py
+++ b/custom_components/ajax/sse_manager.py
@@ -439,13 +439,15 @@ class SSEManager(EventHandlerMixin):
                     _LOGGER.debug("SSE: Sleep completed at t=%dms", int((time.time() - start_time) * 1000))
                     # CRITICAL: Bypass proxy cache to get fresh group states from Ajax API
                     self.coordinator._bypass_cache_next_refresh = True
-                    # Use async_force_metadata_refresh to ensure full_refresh=True
-                    # This updates groups, not just hub state
-                    await self.coordinator.async_force_metadata_refresh()
+                    # Group states are already fetched on every tick (#150), so an
+                    # arm/disarm event only needs an immediate light refresh - not a
+                    # full account-wide metadata pass (rooms/users/video re-fetches
+                    # across all hubs).
+                    await self.coordinator.async_force_state_refresh()
                     elapsed = int((time.time() - start_time) * 1000)
                     _LOGGER.info("SSE: Group refresh completed at t=%dms", elapsed)
                 except Exception as err:
-                    _LOGGER.error("SSE: Metadata refresh failed after security event: %s", err)
+                    _LOGGER.error("SSE: State refresh failed after security event: %s", err)
                     # Fallback: apply SSE state directly since refresh failed
                     if state_changed:
                         space.security_state = new_state

--- a/tests/test_coordinator_core_coverage.py
+++ b/tests/test_coordinator_core_coverage.py
@@ -601,6 +601,18 @@ async def test_async_force_metadata_refresh_sets_flag_and_refreshes() -> None:
     coord.async_refresh.assert_awaited_once()
 
 
+async def test_async_force_state_refresh_refreshes_without_full_flag() -> None:
+    coord = _coordinator()
+    coord._force_metadata_refresh = False
+    coord.async_refresh = AsyncMock()
+
+    await coord.async_force_state_refresh()
+
+    # Light refresh must NOT force the account-wide metadata pass.
+    assert coord._force_metadata_refresh is False
+    coord.async_refresh.assert_awaited_once()
+
+
 async def test_async_request_refresh_bypass_cache_sets_flag() -> None:
     coord = _coordinator()
     coord._bypass_cache_next_refresh = False

--- a/tests/test_sqs_manager_coverage.py
+++ b/tests/test_sqs_manager_coverage.py
@@ -52,6 +52,7 @@ def _make_coordinator() -> MagicMock:
     # Async coordinator hooks
     coord.has_pending_ha_action = MagicMock(return_value=False)
     coord.async_force_metadata_refresh = AsyncMock()
+    coord.async_force_state_refresh = AsyncMock()
     coord._create_sqs_notification = AsyncMock()
     coord._async_save_smart_locks = AsyncMock()
     coord._fire_security_state_event = MagicMock()
@@ -344,7 +345,9 @@ async def test_handle_security_event_arm_refreshes_and_fires(monkeypatch) -> Non
     result = await mgr._handle_security_event(space, "arm", "John", "USER")
     assert result is True
     assert space.security_state == SecurityState.ARMED
-    mgr.coordinator.async_force_metadata_refresh.assert_awaited_once()
+    mgr.coordinator.async_force_state_refresh.assert_awaited_once()
+    mgr.coordinator.async_force_metadata_refresh.assert_not_awaited()
+    assert mgr.coordinator._bypass_cache_next_refresh is True
     mgr.coordinator._create_sqs_notification.assert_awaited_once()
     mgr.coordinator._fire_security_state_event.assert_called_once()
 
@@ -385,6 +388,7 @@ async def test_handle_security_event_night_mode_no_refresh() -> None:
     assert result is True
     assert space.security_state == SecurityState.NIGHT_MODE
     mgr.coordinator.async_force_metadata_refresh.assert_not_awaited()
+    mgr.coordinator.async_force_state_refresh.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -1314,7 +1318,7 @@ def test_create_event_record_security_tag_fallback() -> None:
 async def test_handle_security_event_refresh_failure_clears_flag(monkeypatch) -> None:
     mgr = _make_manager()
     monkeypatch.setattr("custom_components.ajax.sqs_manager.asyncio.sleep", AsyncMock())
-    mgr.coordinator.async_force_metadata_refresh = AsyncMock(side_effect=RuntimeError("boom"))
+    mgr.coordinator.async_force_state_refresh = AsyncMock(side_effect=RuntimeError("boom"))
     space = _space(SecurityState.DISARMED)
     result = await mgr._handle_security_event(space, "arm", "John", "USER")
     assert result is True

--- a/tests/test_sse_manager_coverage.py
+++ b/tests/test_sse_manager_coverage.py
@@ -66,6 +66,7 @@ def _make_manager() -> SSEManager:
         async_set_updated_data=MagicMock(),
         async_request_refresh=AsyncMock(),
         async_force_metadata_refresh=AsyncMock(),
+        async_force_state_refresh=AsyncMock(),
         _create_sqs_notification=AsyncMock(),
         _fire_security_state_event=MagicMock(),
         _update_polling_interval=MagicMock(),
@@ -369,7 +370,8 @@ async def test_security_event_full_arm_triggers_refresh() -> None:
     mgr = _make_manager()
     space = _space(SecurityState.DISARMED)
     await mgr._handle_security_event(space, "arm", "User", "USER")
-    mgr.coordinator.async_force_metadata_refresh.assert_awaited_once()
+    mgr.coordinator.async_force_state_refresh.assert_awaited_once()
+    mgr.coordinator.async_force_metadata_refresh.assert_not_awaited()
     assert mgr.coordinator._bypass_cache_next_refresh is True
     # Skip flag added then removed.
     assert "hub1" not in mgr.coordinator._skipped_state_change_hubs
@@ -378,7 +380,7 @@ async def test_security_event_full_arm_triggers_refresh() -> None:
 async def test_security_event_refresh_failure_applies_fallback_state() -> None:
     mgr = _make_manager()
     space = _space(SecurityState.DISARMED)
-    mgr.coordinator.async_force_metadata_refresh = AsyncMock(side_effect=RuntimeError("api down"))
+    mgr.coordinator.async_force_state_refresh = AsyncMock(side_effect=RuntimeError("api down"))
     await mgr._handle_security_event(space, "arm", "User", "USER")
     # Fallback applied the new state because refresh failed and state changed.
     assert space.security_state == SecurityState.ARMED


### PR DESCRIPTION
## Problem

Every arm/disarm event received over SSE or SQS called `async_force_metadata_refresh()`, which re-runs the **whole account** with `full_refresh=True`: `space_by_hub` + `rooms` + `users` for every hub, then devices + the video/smart-lock fan-out for every space — including sibling hubs that didn't change. Arming one group on hub A re-downloaded rooms/users/devices for hubs B and C. Each arming cycle produced a burst of API calls, almost all of it useless: since the #150 fix, per-group states are fetched on **every** tick anyway, and hub state too. The old SSE comment ("ensure full_refresh=True … updates groups") predated that fix and was stale.

## Fix

New `async_force_state_refresh()`: same debouncer bypass (`async_refresh`, immediate — the whole point of the force) **without** setting the account-wide metadata flag. Both realtime managers now call it after security events; the manual-refresh service keeps the full `async_force_metadata_refresh` (that is the wanted behavior for an explicit human request). Stale comments replaced with the actual rationale.

Bonus parity fix: the SQS path now also sets `_bypass_cache_next_refresh = True` before the refresh (the SSE path already did; both need fresh group state from the API, not the proxy cache).

The #133 dedup structure (`_security_event_lock`, `_skipped_state_change_hubs` add/discard) and the #150 every-tick groups fetch are untouched.

## Tests

New coordinator test asserting the light refresh does NOT set `_force_metadata_refresh`; SSE/SQS security-event tests now assert the light refresh is called, the full one is NOT, and the cache-bypass flag is set; failure-path tests retargeted; service tests confirmed still exercising the full refresh.

## Verification

- `mypy custom_components/ajax/` → 0 errors (strict)
- `ruff check` + `ruff format --check` → clean
- `python -m pytest tests/ --cov=custom_components/ajax` → **1933 passed, 99% coverage**

Note: touches `coordinator.py` and `test_coordinator_core_coverage.py` in regions disjoint from #194 (armed-aware cadence) — the two merge cleanly in either order.