### PR TITLE
perf(coordinator): armed-aware video-edge/smart-lock sync cadence

### DIFF
--- a/custom_components/ajax/coordinator.py
+++ b/custom_components/ajax/coordinator.py
@@ -435,7 +435,24 @@ class AjaxDataCoordinator(
                 # we only poll their full state every Nth cycle (or always on
                 # forced metadata refresh). Direct mode without realtime keeps
                 # the previous behaviour.
-                realtime_active = (self.sse_manager is not None) or (self.sqs_manager is not None)
+                #
+                # SSE/SQS only deliver events while the alarm is armed
+                # (documented Ajax limitation — nothing is pushed while
+                # disarmed). A manager being instantiated is therefore not
+                # enough on its own: require at least one armed / partially
+                # armed / night-mode space before trusting realtime freshness.
+                # All spaces disarmed → REST becomes the only source again,
+                # so poll every cycle, same as the no-manager case.
+                any_space_armed = any(
+                    space.security_state
+                    in (
+                        SecurityState.ARMED,
+                        SecurityState.PARTIALLY_ARMED,
+                        SecurityState.NIGHT_MODE,
+                    )
+                    for space in self.account.spaces.values()
+                )
+                realtime_active = ((self.sse_manager is not None) or (self.sqs_manager is not None)) and any_space_armed
                 refresh_video_smart = (
                     need_metadata_refresh
                     or not realtime_active

--- a/tests/test_coordinator_core_coverage.py
+++ b/tests/test_coordinator_core_coverage.py
@@ -10,7 +10,9 @@ Covered:
   UpdateFailed.
 - ``get_space`` / ``get_device`` / ``get_room`` / ``get_group`` helpers.
 - ``_update_polling_interval`` adaptive interval + door-poll management.
-- realtime_skip_factor throttle of video/smart-lock refresh.
+- realtime_skip_factor throttle of video/smart-lock refresh, armed-aware
+  (manager presence alone is not enough — SSE/SQS deliver nothing while
+  every space is disarmed, so that state forces a refresh every cycle).
 - ``async_shutdown`` (stop SQS / SSE / ONVIF / door poll + close api).
 """
 
@@ -263,14 +265,20 @@ async def test_periodic_update_no_realtime_always_refreshes_video_smart() -> Non
 
 
 async def test_periodic_update_realtime_throttles_video_smart() -> None:
-    """With realtime active and cycle not on the Nth tick, video/smart skip."""
+    """Manager present + an armed space + cycle not on the Nth tick → skip.
+
+    Realtime freshness (SSE/SQS) is only trustworthy while the alarm is
+    armed, so this test uses an ARMED space — a disarmed one would force
+    the refresh regardless of the cycle counter (see the dedicated
+    all-disarmed test below).
+    """
     coord = _coordinator()
     coord._initial_load_done = True
     coord.sse_manager = MagicMock()  # realtime active
     coord._realtime_skip_factor = 3
     coord._cycle_counter = 0  # becomes 1 after increment → 1 % 3 != 0 → skip
     coord._last_metadata_refresh = 1e18
-    coord.account = _account_with_space()
+    coord.account = _account_with_space(SecurityState.ARMED)
     coord.account.spaces["s1"].video_edges["ve1"] = MagicMock()
     coord.account.spaces["s1"].smart_locks["sl1"] = MagicMock()
 
@@ -288,14 +296,43 @@ async def test_periodic_update_realtime_throttles_video_smart() -> None:
 
 
 async def test_periodic_update_realtime_refreshes_on_nth_cycle() -> None:
-    """With realtime active, the Nth cycle still does the full REST sync."""
+    """Manager present + an armed space: the Nth cycle still does the full sync."""
     coord = _coordinator()
     coord._initial_load_done = True
     coord.sqs_manager = MagicMock()  # realtime active
     coord._realtime_skip_factor = 3
     coord._cycle_counter = 2  # becomes 3 after increment → 3 % 3 == 0 → refresh
     coord._last_metadata_refresh = 1e18
-    coord.account = _account_with_space()
+    coord.account = _account_with_space(SecurityState.ARMED)
+    coord.account.spaces["s1"].video_edges["ve1"] = MagicMock()
+    coord.account.spaces["s1"].smart_locks["sl1"] = MagicMock()
+
+    coord._async_update_spaces_from_hubs = AsyncMock()
+    coord._async_update_devices = AsyncMock()
+    coord._async_update_video_edges = AsyncMock()
+    coord._async_update_smart_locks = AsyncMock()
+    coord._reset_expired_motion_detections = MagicMock()
+
+    await coord._async_update_data()
+
+    coord._async_update_video_edges.assert_awaited_once_with("s1")
+    coord._async_update_smart_locks.assert_awaited_once_with("s1")
+
+
+async def test_periodic_update_realtime_manager_but_all_disarmed_always_refreshes() -> None:
+    """Manager present but every space disarmed → SSE/SQS deliver nothing.
+
+    Ajax never pushes real-time events while disarmed, so a manager being
+    instantiated is not enough on its own: the throttle must fall back to
+    polling every cycle, same as the no-manager case, even off the Nth tick.
+    """
+    coord = _coordinator()
+    coord._initial_load_done = True
+    coord.sse_manager = MagicMock()  # manager present...
+    coord._realtime_skip_factor = 3
+    coord._cycle_counter = 0  # becomes 1 after increment → 1 % 3 != 0
+    coord._last_metadata_refresh = 1e18
+    coord.account = _account_with_space(SecurityState.DISARMED)  # ...but disarmed
     coord.account.spaces["s1"].video_edges["ve1"] = MagicMock()
     coord.account.spaces["s1"].smart_locks["sl1"] = MagicMock()
 


### PR DESCRIPTION
## Problem

The video-edge/smart-lock REST sync throttle (every Nth cycle) was gated on the **existence** of an SSE/SQS manager — but Ajax delivers no realtime events while the system is disarmed. So exactly in the state where REST polling is the only update path, the throttle assumed a realtime freshness that wasn't there: camera connection state and REST-sourced fields could lag up to `skip_factor × interval` (≈90 s) while disarmed.

## Fix

`realtime_active` now requires a manager **and** at least one space in `ARMED` / `PARTIALLY_ARMED` / `NIGHT_MODE`. All spaces disarmed → the video/smart sync runs every cycle again (same as the no-manager case). Transitional/alarm states (`TRIGGERED`, exit timers…) deliberately fall back to the always-refresh side — extra freshness exactly when it matters.

This *increases* REST calls in the disarmed state (back to pre-throttle behavior) — that is the point: it corrects a stale-freshness assumption. The budget is offset by #192 (smart-lock detail dedup) and #193 (no more account-wide refresh per arm/disarm).

## Investigated and deliberately NOT done

Spacing the per-camera detail GET out to the hourly metadata cycle. A field-provenance pass over everything `_async_update_video_edges` writes showed why not: `channels[].state[]` is the **only** AI-detection source for installs without ONVIF (and the only source at all while disarmed), and `connection_state` / `raw_data` (CPU/RAM/uptime, wifi signal, firmware update progress) are live REST-only telemetry. Spacing that GET would starve exactly the most visible attributes. Revisit only if an alternative source for those fields appears.

## Tests

New test: manager present + all spaces disarmed → refresh every cycle even off the Nth tick. The two existing throttle tests now use an explicitly ARMED space (they relied incidentally on the builder's disarmed default); the no-manager test is untouched.

## Verification

- `mypy custom_components/ajax/` → 0 errors (strict)
- `ruff check` + `ruff format --check` → clean
- `python -m pytest tests/ --cov=custom_components/ajax` → **1933 passed, 99% coverage**

Note: touches `coordinator.py` and `test_coordinator_core_coverage.py` in regions disjoint from #193 — the two merge cleanly in either order.