### PR TITLE
perf(realtime): event-driven refresh budget — characterization tests + 3 interaction fixes

### DIFF
--- a/custom_components/ajax/api/_base.py
+++ b/custom_components/ajax/api/_base.py
@@ -136,6 +136,12 @@ class AjaxRestClientBase:
         # bypass actually targets. A short window safely covers one full refresh
         # cycle (which completes well under 1s) and auto-expires.
         self._bypass_cache_until: float = 0.0
+        # When the currently-open bypass window was opened (set alongside
+        # _bypass_cache_until in bypass_cache_next()). Used by
+        # _cache_entry_usable() to tell an entry fetched fresh INSIDE the
+        # window (safe to reuse for the rest of it) from one written before
+        # the window opened (must be skipped).
+        self._bypass_cache_opened_at: float = 0.0
 
         # Rate limiting state
         # (bypass_cache_next() is a public helper; see below.)
@@ -219,19 +225,39 @@ class AjaxRestClientBase:
         return self.session
 
     def bypass_cache_next(self) -> None:
-        """Force the upcoming refresh cycle to skip every cache layer.
+        """Force the upcoming refresh cycle to fetch each cache key fresh at most once.
 
         Public API used by the coordinator after SSE/SQS events or user actions.
         Opens a short 2s window during which both the proxy cache (via the
-        X-Cache-Control: no-cache header) and the in-memory caches are bypassed,
-        so the device/space getters that run later in the same refresh reach the
-        real endpoint instead of serving stale state.
+        X-Cache-Control: no-cache header) and the in-memory caches ignore any
+        entry written before the window opened, so the device/space getters
+        that run later in the same refresh reach the real endpoint instead of
+        serving stale state. Within the window itself, a key already fetched
+        fresh is still served from the in-memory cache to same-tick callers
+        (e.g. ``async_get_video_edges`` and ``async_get_smart_locks`` both
+        reading the same space) — the window guarantees freshness, not a
+        forced re-fetch per call. See ``_cache_entry_usable()``.
         """
-        self._bypass_cache_until = time.time() + 2.0
+        self._bypass_cache_opened_at = time.time()
+        self._bypass_cache_until = self._bypass_cache_opened_at + 2.0
 
     def _cache_bypass_active(self) -> bool:
         """Return True while the cache-bypass window is open."""
         return time.time() < self._bypass_cache_until
+
+    def _cache_entry_usable(self, written_at: float, ttl: float) -> bool:
+        """True if a cache entry may be served instead of re-fetching.
+
+        Within TTL always; additionally, while a bypass window is open, only
+        if the entry was written AFTER the window opened — a fetch done
+        inside the window is already fresh, so serving it to a second
+        same-tick caller preserves the coalescing the caches exist for,
+        while an entry written before the window opened is exactly the
+        stale state the bypass is meant to skip.
+        """
+        if (time.time() - written_at) >= ttl:
+            return False
+        return not (self._cache_bypass_active() and written_at < self._bypass_cache_opened_at)
 
     async def close(self) -> None:
         """Close the session if we own it."""

--- a/custom_components/ajax/api/_devices.py
+++ b/custom_components/ajax/api/_devices.py
@@ -79,13 +79,15 @@ class _DevicesMixin(AjaxRestClientBase):
         Returns:
             List of device dictionaries (with full details if enrich=True)
         """
-        # Serve from the short-lived cache unless a cache bypass is pending
-        # (bypass must reach the real endpoint to get fresh state).
+        # Serve from the short-lived cache unless the entry predates an open
+        # bypass window (see _cache_entry_usable()): a fresh fetch inside the
+        # window is reused by the next same-tick caller (periodic loop and
+        # door-sensor fast-poll crossing paths), so the endpoint is hit at
+        # most once per window instead of once per caller.
         cache_key = (hub_id, enrich)
-        if not self._cache_bypass_active():
-            cached = self._devices_cache.get(cache_key)
-            if cached and (time.time() - cached[0]) < self._devices_cache_ttl:
-                return cached[1]
+        cached = self._devices_cache.get(cache_key)
+        if cached and self._cache_entry_usable(cached[0], self._devices_cache_ttl):
+            return cached[1]
 
         if not self.user_id:
             raise AjaxRestApiError("No user_id available. Call async_login() first.")

--- a/custom_components/ajax/api/_video.py
+++ b/custom_components/ajax/api/_video.py
@@ -23,12 +23,14 @@ class _VideoMixin(AjaxRestClientBase):
         Returns:
             Space dictionary with devices array
         """
-        # Skip the in-memory cache while a bypass window is open so the fresh
-        # space payload (which feeds video-edges and smart-locks) is fetched.
-        if not self._cache_bypass_active():
-            cached = self._space_cache.get(space_id)
-            if cached and (time.time() - cached[0]) < self._space_cache_ttl:
-                return cached[1]
+        # Serve a cache entry unless it predates an open bypass window (see
+        # _cache_entry_usable()): a fresh fetch inside the window is reused
+        # by the next same-tick caller (async_get_video_edges then
+        # async_get_smart_locks), so the space payload is fetched at most
+        # once per window instead of once per caller.
+        cached = self._space_cache.get(space_id)
+        if cached and self._cache_entry_usable(cached[0], self._space_cache_ttl):
+            return cached[1]
         data = await self._request("GET", f"user/{self.user_id}/spaces/{space_id}")
         self._space_cache[space_id] = (time.time(), data)
         return data  # type: ignore[no-any-return]

--- a/custom_components/ajax/coordinator.py
+++ b/custom_components/ajax/coordinator.py
@@ -198,6 +198,10 @@ class AjaxDataCoordinator(
         # Flag to bypass proxy cache on next refresh (after SSE event or user action)
         self._bypass_cache_next_refresh: bool = False
 
+        # Set by async_force_state_refresh; the next _async_update_data run skips
+        # the cycle counter and the video/smart-lock fan-out.
+        self._light_refresh_pending: bool = False
+
         # Auth error resilience: tolerate transient auth failures before triggering reauth
         self._consecutive_auth_errors: int = 0
         self._max_auth_errors: int = 3  # Trigger reauth after 3 consecutive auth failures
@@ -308,8 +312,18 @@ class AjaxDataCoordinator(
         account-wide metadata pass: hub state and per-group states are
         fetched on every tick anyway (#150), so an arm/disarm event only
         needs immediacy - not rooms/users/video re-fetches across all hubs.
+
+        Sets ``_light_refresh_pending`` so the upcoming ``_async_update_data``
+        run neither advances the #194 armed-aware cycle counter nor performs
+        the video-edge/smart-lock fan-out, even if the throttle's modulo
+        would otherwise land on it or the affected space just went from
+        armed to disarmed. Trade-off: video AI detections and smart-lock
+        state discovered off an arm/disarm event catch up on the next
+        regular periodic tick (UPDATE_INTERVAL, see const.py) instead of
+        immediately.
         """
         _LOGGER.info("Forcing light state refresh (immediate)")
+        self._light_refresh_pending = True
         await self.async_refresh()
 
     async def async_request_refresh_bypass_cache(self) -> None:
@@ -338,6 +352,12 @@ class AjaxDataCoordinator(
                 self.api.bypass_cache_next()
                 self._bypass_cache_next_refresh = False
                 _LOGGER.debug("Bypassing proxy cache for this refresh")
+
+            # Consume the light-refresh flag set by async_force_state_refresh:
+            # this tick must not advance the cycle counter or trigger the
+            # video/smart-lock fan-out (see refresh_video_smart below).
+            light_refresh = self._light_refresh_pending
+            self._light_refresh_pending = False
 
             # Initialize account if needed
             if self.account is None:
@@ -441,7 +461,12 @@ class AjaxDataCoordinator(
                 # Light or full update based on metadata refresh need
                 await self._async_update_spaces_from_hubs(full_refresh=need_metadata_refresh)
 
-                self._cycle_counter += 1
+                # A light refresh (async_force_state_refresh, after a realtime
+                # security event) must not advance the cadence used by the
+                # throttle below - otherwise a burst of events skews the
+                # "every Nth cycle" schedule for everyone, armed or not.
+                if not light_refresh:
+                    self._cycle_counter += 1
                 # When real-time events are flowing in, video edges and smart
                 # locks are kept fresh by SSE/SQS. Throttle the REST sync so
                 # we only poll their full state every Nth cycle (or always on
@@ -465,10 +490,15 @@ class AjaxDataCoordinator(
                     for space in self.account.spaces.values()
                 )
                 realtime_active = ((self.sse_manager is not None) or (self.sqs_manager is not None)) and any_space_armed
-                refresh_video_smart = (
-                    need_metadata_refresh
-                    or not realtime_active
-                    or (self._cycle_counter % self._realtime_skip_factor == 0)
+                # A light refresh never does the video/smart-lock fan-out on
+                # its own - not because of a phase-alignment fluke in the
+                # modulo above, and not because the space it just disarmed
+                # looks unarmed for this tick's realtime_active check. Only an
+                # explicit need_metadata_refresh (unrelated to this refresh
+                # being "light") still forces it.
+                refresh_video_smart = need_metadata_refresh or (
+                    not light_refresh
+                    and (not realtime_active or (self._cycle_counter % self._realtime_skip_factor == 0))
                 )
 
                 for space_id in self.account.spaces:

--- a/custom_components/ajax/coordinator.py
+++ b/custom_components/ajax/coordinator.py
@@ -202,6 +202,10 @@ class AjaxDataCoordinator(
         # the cycle counter and the video/smart-lock fan-out.
         self._light_refresh_pending: bool = False
 
+        # Wall-clock start of the last forced light refresh; realtime managers
+        # use it to coalesce event bursts.
+        self._last_forced_state_refresh_started: float = 0.0
+
         # Auth error resilience: tolerate transient auth failures before triggering reauth
         self._consecutive_auth_errors: int = 0
         self._max_auth_errors: int = 3  # Trigger reauth after 3 consecutive auth failures
@@ -324,6 +328,7 @@ class AjaxDataCoordinator(
         """
         _LOGGER.info("Forcing light state refresh (immediate)")
         self._light_refresh_pending = True
+        self._last_forced_state_refresh_started = time.time()
         await self.async_refresh()
 
     async def async_request_refresh_bypass_cache(self) -> None:

--- a/custom_components/ajax/sqs_manager.py
+++ b/custom_components/ajax/sqs_manager.py
@@ -457,6 +457,7 @@ class SQSManager(EventHandlerMixin):
         is_full_arm_disarm = event_tag in FULL_ARM_EVENT_TAGS
 
         if is_group_event or is_full_arm_disarm:
+            event_received = time.time()
             _LOGGER.info(
                 "SQS: Security event '%s' detected for hub %s, refreshing groups",
                 event_tag,
@@ -467,28 +468,43 @@ class SQSManager(EventHandlerMixin):
             # tick landing in the 1s window sees the flag still False and
             # fires a duplicate ajax_armed/ajax_disarmed bus event (#133).
             async with self._security_event_lock:
-                try:
-                    # Skip REST-side event creation for THIS hub until the refresh is done
-                    if space.hub_id:
-                        self.coordinator._skipped_state_change_hubs.add(space.hub_id)
-                    # Wait for Ajax backend to process the change before refreshing
-                    # Without this delay, the API may return stale state
-                    await asyncio.sleep(1.0)
-                    # Bypass proxy cache to get fresh group states from Ajax API
-                    # (parity with the SSE path)
-                    self.coordinator._bypass_cache_next_refresh = True
-                    # Group states are already fetched on every tick (#150), so an
-                    # arm/disarm event only needs an immediate light refresh - not a
-                    # full account-wide metadata pass (rooms/users/video re-fetches
-                    # across all hubs).
-                    await self.coordinator.async_force_state_refresh()
-                    _LOGGER.info("SQS: State refresh completed after security event")
-                except Exception as err:
-                    _LOGGER.error("SQS: State refresh failed after security event: %s", err)
-                finally:
-                    # Always clear the per-hub skip flag
-                    if space.hub_id:
-                        self.coordinator._skipped_state_change_hubs.discard(space.hub_id)
+                # A forced refresh that STARTED after this event was received
+                # has already fetched backend state covering it - re-running
+                # the whole sleep+refresh sequence would just repeat the same
+                # REST calls (multi-group "arm all" bursts emit one event per
+                # group). Skip the skip-set/sleep/bypass-flag/refresh
+                # entirely for a coalesced event; per-event notification /
+                # history / bus-event handling below still runs unconditionally.
+                already_covered = self.coordinator._last_forced_state_refresh_started >= event_received
+                if already_covered:
+                    _LOGGER.debug(
+                        "SQS: Security event '%s' coalesced into the refresh started at %.3f",
+                        event_tag,
+                        self.coordinator._last_forced_state_refresh_started,
+                    )
+                else:
+                    try:
+                        # Skip REST-side event creation for THIS hub until the refresh is done
+                        if space.hub_id:
+                            self.coordinator._skipped_state_change_hubs.add(space.hub_id)
+                        # Wait for Ajax backend to process the change before refreshing
+                        # Without this delay, the API may return stale state
+                        await asyncio.sleep(1.0)
+                        # Bypass proxy cache to get fresh group states from Ajax API
+                        # (parity with the SSE path)
+                        self.coordinator._bypass_cache_next_refresh = True
+                        # Group states are already fetched on every tick (#150), so an
+                        # arm/disarm event only needs an immediate light refresh - not a
+                        # full account-wide metadata pass (rooms/users/video re-fetches
+                        # across all hubs).
+                        await self.coordinator.async_force_state_refresh()
+                        _LOGGER.info("SQS: State refresh completed after security event")
+                    except Exception as err:
+                        _LOGGER.error("SQS: State refresh failed after security event: %s", err)
+                    finally:
+                        # Always clear the per-hub skip flag
+                        if space.hub_id:
+                            self.coordinator._skipped_state_change_hubs.discard(space.hub_id)
 
         # Skip state update if HA action is pending (protect optimistic update)
         # But still record the event in history and create notification

--- a/custom_components/ajax/sse_manager.py
+++ b/custom_components/ajax/sse_manager.py
@@ -429,34 +429,49 @@ class SSEManager(EventHandlerMixin):
             # tick landing in the 0.3s window sees the flag still False and
             # fires a duplicate ajax_armed/ajax_disarmed bus event (#133).
             async with self._security_event_lock:
-                try:
-                    # Skip REST-side event creation for THIS hub until the refresh is done
-                    if space.hub_id:
-                        self.coordinator._skipped_state_change_hubs.add(space.hub_id)
-                    # Small delay to let Ajax backend process the change
-                    # Reduced from 1.0s to 0.3s for faster real-time updates
-                    await asyncio.sleep(0.3)
-                    _LOGGER.debug("SSE: Sleep completed at t=%dms", int((time.time() - start_time) * 1000))
-                    # CRITICAL: Bypass proxy cache to get fresh group states from Ajax API
-                    self.coordinator._bypass_cache_next_refresh = True
-                    # Group states are already fetched on every tick (#150), so an
-                    # arm/disarm event only needs an immediate light refresh - not a
-                    # full account-wide metadata pass (rooms/users/video re-fetches
-                    # across all hubs).
-                    await self.coordinator.async_force_state_refresh()
-                    elapsed = int((time.time() - start_time) * 1000)
-                    _LOGGER.info("SSE: Group refresh completed at t=%dms", elapsed)
-                except Exception as err:
-                    _LOGGER.error("SSE: State refresh failed after security event: %s", err)
-                    # Fallback: apply SSE state directly since refresh failed
-                    if state_changed:
-                        space.security_state = new_state
-                        self._last_state_update[space.hub_id] = time.time()  # type: ignore[index]
-                        _LOGGER.info("SSE: Fallback state update applied after refresh failure")
-                finally:
-                    # Always clear the per-hub skip flag
-                    if space.hub_id:
-                        self.coordinator._skipped_state_change_hubs.discard(space.hub_id)
+                # A forced refresh that STARTED after this event was received
+                # has already fetched backend state covering it - re-running
+                # the whole sleep+refresh sequence would just repeat the same
+                # REST calls (multi-group "arm all" bursts emit one event per
+                # group). Skip the skip-set/sleep/bypass-flag/refresh/fallback
+                # entirely for a coalesced event; per-event notification /
+                # history / bus-event handling below still runs unconditionally.
+                already_covered = self.coordinator._last_forced_state_refresh_started >= start_time
+                if already_covered:
+                    _LOGGER.debug(
+                        "SSE: Security event '%s' coalesced into the refresh started at %.3f",
+                        event_tag,
+                        self.coordinator._last_forced_state_refresh_started,
+                    )
+                else:
+                    try:
+                        # Skip REST-side event creation for THIS hub until the refresh is done
+                        if space.hub_id:
+                            self.coordinator._skipped_state_change_hubs.add(space.hub_id)
+                        # Small delay to let Ajax backend process the change
+                        # Reduced from 1.0s to 0.3s for faster real-time updates
+                        await asyncio.sleep(0.3)
+                        _LOGGER.debug("SSE: Sleep completed at t=%dms", int((time.time() - start_time) * 1000))
+                        # CRITICAL: Bypass proxy cache to get fresh group states from Ajax API
+                        self.coordinator._bypass_cache_next_refresh = True
+                        # Group states are already fetched on every tick (#150), so an
+                        # arm/disarm event only needs an immediate light refresh - not a
+                        # full account-wide metadata pass (rooms/users/video re-fetches
+                        # across all hubs).
+                        await self.coordinator.async_force_state_refresh()
+                        elapsed = int((time.time() - start_time) * 1000)
+                        _LOGGER.info("SSE: Group refresh completed at t=%dms", elapsed)
+                    except Exception as err:
+                        _LOGGER.error("SSE: State refresh failed after security event: %s", err)
+                        # Fallback: apply SSE state directly since refresh failed
+                        if state_changed:
+                            space.security_state = new_state
+                            self._last_state_update[space.hub_id] = time.time()  # type: ignore[index]
+                            _LOGGER.info("SSE: Fallback state update applied after refresh failure")
+                    finally:
+                        # Always clear the per-hub skip flag
+                        if space.hub_id:
+                            self.coordinator._skipped_state_change_hubs.discard(space.hub_id)
 
         # Update state immediately only for events that don't trigger a refresh
         # For group and full arm/disarm events, the metadata refresh will update the state

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -110,6 +110,22 @@ async def test_async_get_devices_cache_bypassed_when_bypass_flag_set() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_get_devices_bypass_window_reuses_fetch_for_second_caller() -> None:
+    """Plan 010: a fetch done INSIDE the bypass window is reused by the next
+    same-tick caller for the same key — the window guarantees at most one
+    fresh fetch per key, not one fetch per caller (periodic loop and
+    door-sensor fast-poll crossing paths within the same window)."""
+    api = _api()
+    api._request.return_value = [{"id": "d1"}]
+
+    api.bypass_cache_next()
+    await api.async_get_devices("h1")  # fresh fetch inside the window
+    await api.async_get_devices("h1")  # same window, same key -> cache hit
+
+    assert api._request.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_async_get_devices_cache_expires_after_ttl() -> None:
     """Past the TTL window, a fresh request must fire."""
     api = _api()

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -188,6 +188,58 @@ def test_bypass_cache_window_expires() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _cache_entry_usable — while a bypass window is open, an entry fetched fresh
+# INSIDE it is still served to the next same-tick caller; only entries older
+# than the window's opening are treated as stale (plan 010). This is what
+# lets async_get_video_edges and async_get_smart_locks share a single
+# GET /spaces/{id} fetch per bypass window instead of one each.
+# ---------------------------------------------------------------------------
+
+
+def test_cache_entry_written_before_window_is_not_usable() -> None:
+    """An entry cached before the bypass window opened must be refetched."""
+    api = AjaxRestApi(api_key="k", email="u@example.com", password="p")
+    now = time.time()
+    written_at = now - 1.0  # cached well before the window opened
+    api._bypass_cache_opened_at = now
+    api._bypass_cache_until = now + 2.0
+    assert api._cache_entry_usable(written_at, ttl=5.0) is False
+
+
+def test_cache_entry_written_during_window_is_usable() -> None:
+    """A fetch done inside the window is fresh — a second same-tick caller reuses it."""
+    api = AjaxRestApi(api_key="k", email="u@example.com", password="p")
+    now = time.time()
+    api._bypass_cache_opened_at = now
+    api._bypass_cache_until = now + 2.0
+    written_at = now + 0.1  # fetched just after the window opened
+    assert api._cache_entry_usable(written_at, ttl=5.0) is True
+
+
+def test_cache_entry_respects_ttl_regardless_of_bypass_window() -> None:
+    """An entry past its TTL is never usable, bypass window or not."""
+    api = AjaxRestApi(api_key="k", email="u@example.com", password="p")
+    stale_written_at = time.time() - 10.0
+    assert api._cache_entry_usable(stale_written_at, ttl=5.0) is False
+
+
+def test_cache_entry_usable_falls_back_to_ttl_once_window_expired() -> None:
+    """Once the bypass window has closed, only the TTL decides again.
+
+    An entry that would have been rejected while the window was open (it
+    predates ``_bypass_cache_opened_at``) is usable once the window itself
+    has expired — the special "must postdate the window" rule only applies
+    while a bypass is actually in progress.
+    """
+    api = AjaxRestApi(api_key="k", email="u@example.com", password="p")
+    now = time.time()
+    written_at = now - 1.0
+    api._bypass_cache_opened_at = now
+    api._bypass_cache_until = now - 0.5  # window already closed
+    assert api._cache_entry_usable(written_at, ttl=5.0) is True
+
+
+# ---------------------------------------------------------------------------
 # _check_rate_limit
 # ---------------------------------------------------------------------------
 

--- a/tests/test_coordinator_core_coverage.py
+++ b/tests/test_coordinator_core_coverage.py
@@ -74,6 +74,7 @@ def _coordinator() -> AjaxDataCoordinator:
     coord._initial_load_done = False
     coord._force_metadata_refresh = False
     coord._bypass_cache_next_refresh = False
+    coord._light_refresh_pending = False
     coord._cycle_counter = 0
     coord._realtime_skip_factor = 3
     coord._last_metadata_refresh = 0.0
@@ -346,6 +347,71 @@ async def test_periodic_update_realtime_manager_but_all_disarmed_always_refreshe
 
     coord._async_update_video_edges.assert_awaited_once_with("s1")
     coord._async_update_smart_locks.assert_awaited_once_with("s1")
+
+
+async def test_light_refresh_pending_skips_counter_and_fan_out_even_when_disarmed() -> None:
+    """A light refresh (plan 009) skips the fan-out unconditionally.
+
+    Neither the Nth-cycle modulo nor the "all spaces disarmed -> poll every
+    cycle" fallback gets a vote once _light_refresh_pending is set — only an
+    explicit need_metadata_refresh overrides it (see the forced-metadata
+    test below).
+    """
+    coord = _coordinator()
+    coord._initial_load_done = True
+    coord._light_refresh_pending = True
+    coord.sse_manager = None
+    coord.sqs_manager = None
+    coord._realtime_skip_factor = 3
+    coord._cycle_counter = 2  # would become 3 -> 3 % 3 == 0 if incremented
+    coord._last_metadata_refresh = 1e18
+    coord.account = _account_with_space(SecurityState.DISARMED)  # would also force a refresh on its own
+    coord.account.spaces["s1"].video_edges["ve1"] = MagicMock()
+    coord.account.spaces["s1"].smart_locks["sl1"] = MagicMock()
+
+    coord._async_update_spaces_from_hubs = AsyncMock()
+    coord._async_update_devices = AsyncMock()
+    coord._async_update_video_edges = AsyncMock()
+    coord._async_update_smart_locks = AsyncMock()
+    coord._reset_expired_motion_detections = MagicMock()
+
+    await coord._async_update_data()
+
+    assert coord._cycle_counter == 2  # unchanged — the increment was skipped
+    assert coord._light_refresh_pending is False  # consumed
+    coord._async_update_video_edges.assert_not_awaited()
+    coord._async_update_smart_locks.assert_not_awaited()
+
+
+async def test_light_refresh_pending_does_not_stick_to_the_next_tick() -> None:
+    """The _light_refresh_pending flag is consumed once; the next ordinary tick behaves normally."""
+    coord = _coordinator()
+    coord._initial_load_done = True
+    coord._light_refresh_pending = True
+    coord.sse_manager = None
+    coord.sqs_manager = None
+    coord._last_metadata_refresh = 1e18
+    coord.account = _account_with_space(SecurityState.DISARMED)
+    coord.account.spaces["s1"].video_edges["ve1"] = MagicMock()
+    coord.account.spaces["s1"].smart_locks["sl1"] = MagicMock()
+
+    coord._async_update_spaces_from_hubs = AsyncMock()
+    coord._async_update_devices = AsyncMock()
+    coord._async_update_video_edges = AsyncMock()
+    coord._async_update_smart_locks = AsyncMock()
+    coord._reset_expired_motion_detections = MagicMock()
+
+    await coord._async_update_data()  # light tick: fan-out + counter increment skipped
+
+    coord._async_update_video_edges.assert_not_awaited()
+    assert coord._cycle_counter == 0
+    assert coord._light_refresh_pending is False
+
+    await coord._async_update_data()  # ordinary periodic tick: normal behaviour resumes
+
+    coord._async_update_video_edges.assert_awaited_once_with("s1")
+    coord._async_update_smart_locks.assert_awaited_once_with("s1")
+    assert coord._cycle_counter == 1
 
 
 async def test_periodic_update_forced_metadata_refresh_clears_flag() -> None:
@@ -641,12 +707,16 @@ async def test_async_force_metadata_refresh_sets_flag_and_refreshes() -> None:
 async def test_async_force_state_refresh_refreshes_without_full_flag() -> None:
     coord = _coordinator()
     coord._force_metadata_refresh = False
+    coord._light_refresh_pending = False
     coord.async_refresh = AsyncMock()
 
     await coord.async_force_state_refresh()
 
     # Light refresh must NOT force the account-wide metadata pass.
     assert coord._force_metadata_refresh is False
+    # It DOES set the light-refresh flag so the upcoming _async_update_data
+    # tick skips the cycle counter and the video/smart-lock fan-out (plan 009).
+    assert coord._light_refresh_pending is True
     coord.async_refresh.assert_awaited_once()
 
 

--- a/tests/test_event_refresh_budget.py
+++ b/tests/test_event_refresh_budget.py
@@ -31,8 +31,16 @@ Plan 010 has also landed: ``api/_base.py``'s ``bypass_cache_next()`` now
 records when the window opened (``_bypass_cache_opened_at``), and
 ``_cache_entry_usable()`` only rejects entries written before that instant
 — a fetch done inside the window is still reused by the next same-tick
-caller. Only the plan 011 (burst coalescing) BASELINE assertion remains
-open.
+caller.
+
+Plan 011 has also landed: ``coordinator.py`` now records when the last
+forced light refresh started (``_last_forced_state_refresh_started``), and
+both ``sse_manager.py``/``sqs_manager.py`` skip their own
+skip-set/sleep/bypass-flag/refresh sequence when a refresh that started
+after their event was received already covers it — a burst of
+near-simultaneous group-arm events coalesces into a single tick instead of
+one per event. No plan-011 BASELINE assertion remains open; none of the
+three plans chained from plan 008 do.
 
 The only mocked "bridge" in the coordinator builder is ``async_refresh``
 itself, which stands in for ``DataUpdateCoordinator``'s real
@@ -145,6 +153,7 @@ def _coordinator(security_state: SecurityState = SecurityState.ARMED) -> AjaxDat
     coord._force_metadata_refresh = False
     coord._bypass_cache_next_refresh = False
     coord._light_refresh_pending = False
+    coord._last_forced_state_refresh_started = 0.0
     coord._cycle_counter = 0
     coord._realtime_skip_factor = 3
     coord._last_metadata_refresh = 1e18  # far future -> no metadata refresh
@@ -350,26 +359,80 @@ async def test_sqs_arm_event_triggers_real_coordinator_tick(monkeypatch: pytest.
 # ---------------------------------------------------------------------------
 
 
-async def test_group_event_burst_runs_one_tick_per_event(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Three distinct group-arm events in a row each run their own full tick."""
-    monkeypatch.setattr("custom_components.ajax.sqs_manager.asyncio.sleep", AsyncMock())
+async def test_group_event_burst_coalesces_into_one_tick(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Three near-simultaneous group-arm events coalesce into a single tick (plan 011).
+
+    Production delivers a burst of SQS/SSE messages as concurrent asyncio
+    tasks (``sqs_client.py``/``sse_client.py`` both dispatch each message via
+    ``asyncio.gather``/``create_task``, not one after another), so this test
+    drives the 3 events the same way, via ``asyncio.gather`` — sequential
+    ``await``s (as this test used to do) would never let events 2 and 3
+    queue up on ``_security_event_lock`` before event 1's refresh starts,
+    which would defeat the coalescing regardless of whether it works.
+
+    The stock no-op sleep patch used elsewhere in this file
+    (``AsyncMock()``) never actually suspends the awaiting coroutine —
+    nothing yields, so ``asyncio.gather`` would still just run the 3 tasks
+    one after another to completion, the same false negative as the
+    sequential form. Swap in a real (but zero-duration) ``asyncio.sleep(0)``
+    instead: the yield is genuine, so events 2 and 3 get to capture their
+    own "received" timestamp and queue on the lock before event 1's refresh
+    sets ``_last_forced_state_refresh_started`` — real concurrency, not a
+    contrived clock. Verified empirically (ad hoc script) that the no-op
+    patch produces 3 ticks here and the real-yield patch produces 1.
+    """
     coord = _coordinator(SecurityState.ARMED)
     mgr = _make_manager(coord)
     coord.sqs_manager = mgr
 
-    for idx, group_id in enumerate(("g1", "g2", "g3")):
-        handled = await mgr._handle_event(_sqs_event("grouparm", source_id=group_id, timestamp=1700000000000 + idx))
-        assert handled is True
+    real_sleep = asyncio.sleep
 
-    # BASELINE (plan 011): no coalescing across the burst — 3 independent
-    # group-arm events produce 3 independent _async_update_data() ticks
-    # (each with its own 1.0s internal sleep, here patched to no-op), even
-    # though group states are already refetched on every tick (#150) and a
-    # single coalesced refresh would have been enough.
-    assert coord._async_update_devices.await_count == 3
-    # Each tick is a light refresh (plan 009): none of them advances the
-    # #194 throttle cadence, however many ran.
+    async def _instant_yield(_delay: float) -> None:
+        await real_sleep(0)
+
+    monkeypatch.setattr("custom_components.ajax.sqs_manager.asyncio.sleep", _instant_yield)
+
+    events = [
+        _sqs_event("grouparm", source_id=g, timestamp=1700000000000 + i) for i, g in enumerate(("g1", "g2", "g3"))
+    ]
+    handled = await asyncio.gather(*(mgr._handle_event(e) for e in events))
+
+    assert handled == [True, True, True]
+    # Coalescing: a burst that used to produce 3 independent
+    # _async_update_data() ticks (each with its own 1.0s internal sleep)
+    # now produces 1 — dedup on the group id still lets all 3 events
+    # through (each keeps its own notification/history entry, unaffected).
+    assert coord._async_update_devices.await_count == 1
+    # Each tick is still a light refresh (plan 009): it does not advance
+    # the #194 throttle cadence.
     assert coord._cycle_counter == 0
+
+
+async def test_group_event_spaced_out_does_not_over_coalesce(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two events far enough apart that the 2nd is only received after the
+    1st's refresh has already started still produce 2 independent ticks —
+    the coalescing must not swallow genuinely separate actions."""
+    coord = _coordinator(SecurityState.ARMED)
+    mgr = _make_manager(coord)
+    coord.sqs_manager = mgr
+
+    real_sleep = asyncio.sleep
+
+    async def _instant_yield(_delay: float) -> None:
+        await real_sleep(0)
+
+    monkeypatch.setattr("custom_components.ajax.sqs_manager.asyncio.sleep", _instant_yield)
+
+    e1 = _sqs_event("grouparm", source_id="g1", timestamp=1700000000000)
+    e2 = _sqs_event("grouparm", source_id="g2", timestamp=1700000000001)
+
+    # Awaited fully to completion (including its own refresh) before the
+    # second event is even received — unlike the burst test above, there is
+    # nothing left in flight to interleave with.
+    assert await mgr._handle_event(e1) is True
+    assert await mgr._handle_event(e2) is True
+
+    assert coord._async_update_devices.await_count == 2
 
 
 async def test_disarm_event_light_refresh_skips_video_and_locks(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_event_refresh_budget.py
+++ b/tests/test_event_refresh_budget.py
@@ -20,6 +20,15 @@ and 011 (burst coalescing) each tighten one of the assertions marked
 ``# BASELINE`` below — that is expected and will require updating this
 file, not a regression in it.
 
+Plan 009 has landed: ``async_force_state_refresh()`` now sets
+``_light_refresh_pending`` before calling ``async_refresh()``, and
+``_async_update_data()`` consumes that flag to skip both the
+``_cycle_counter`` increment and the video/smart-lock fan-out
+unconditionally. The tests that used to carry a plan-009 baseline marker
+now assert the fixed (no fan-out / no counter drift) behaviour instead;
+only the plan 010 (bypass single-miss) and plan 011 (burst coalescing)
+BASELINE assertions remain open.
+
 The only mocked "bridge" in the coordinator builder is ``async_refresh``
 itself, which stands in for ``DataUpdateCoordinator``'s real
 ``async_refresh`` (never initialised here, since ``__init__`` is bypassed)
@@ -130,6 +139,7 @@ def _coordinator(security_state: SecurityState = SecurityState.ARMED) -> AjaxDat
     coord._initial_load_done = True
     coord._force_metadata_refresh = False
     coord._bypass_cache_next_refresh = False
+    coord._light_refresh_pending = False
     coord._cycle_counter = 0
     coord._realtime_skip_factor = 3
     coord._last_metadata_refresh = 1e18  # far future -> no metadata refresh
@@ -324,7 +334,9 @@ async def test_sqs_arm_event_triggers_real_coordinator_tick(monkeypatch: pytest.
     # _async_update_devices is unconditional every tick, so one await means
     # one real pass through the coordinator's periodic-update branch.
     coord._async_update_devices.assert_awaited_once_with("s1")
-    assert coord._cycle_counter == 1
+    # This tick went through async_force_state_refresh() (a "light" refresh,
+    # plan 009), which must not advance the #194 throttle cadence.
+    assert coord._cycle_counter == 0
     assert space.security_state == SecurityState.ARMED
 
 
@@ -350,14 +362,20 @@ async def test_group_event_burst_runs_one_tick_per_event(monkeypatch: pytest.Mon
     # though group states are already refetched on every tick (#150) and a
     # single coalesced refresh would have been enough.
     assert coord._async_update_devices.await_count == 3
-    assert coord._cycle_counter == 3
+    # Each tick is a light refresh (plan 009): none of them advances the
+    # #194 throttle cadence, however many ran.
+    assert coord._cycle_counter == 0
 
 
-async def test_disarm_event_light_refresh_fetches_video_and_locks(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A realtime-triggered 'light' refresh can still do the full REST fan-out."""
+async def test_disarm_event_light_refresh_skips_video_and_locks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A realtime-triggered 'light' refresh never does the video/smart-lock fan-out (plan 009)."""
     monkeypatch.setattr("custom_components.ajax.sqs_manager.asyncio.sleep", AsyncMock())
     coord = _coordinator(SecurityState.ARMED)
-    # Land the upcoming tick on the Nth cycle of the #194 throttle.
+    # Land the upcoming tick on the Nth cycle of the #194 throttle — on
+    # purpose: this is exactly the phase that used to trigger the fan-out
+    # (see plan 008's BASELINE finding) before the _light_refresh_pending
+    # flag started overriding the modulo. Keeping this setup is the proof
+    # that the flag wins over the throttle's phase.
     coord._cycle_counter = coord._realtime_skip_factor - 1
     mgr = _make_manager(coord)
     coord.sqs_manager = mgr
@@ -371,33 +389,50 @@ async def test_disarm_event_light_refresh_fetches_video_and_locks(monkeypatch: p
     # assignment is textually after the "if is_group_event or
     # is_full_arm_disarm" block, sqs_manager.py:459-499) — so at the moment
     # _async_update_data() actually runs, the space still reports ARMED and
-    # realtime_active is still True. What forces the fetch below is the
-    # Nth-cycle sync cadence set up above, not "disarmed -> poll every
-    # cycle" (that path is covered by test_periodic_tick_... instead).
-    #
-    # BASELINE (plan 009): async_force_state_refresh's docstring promises a
-    # refresh "WITHOUT ... rooms/users/video re-fetches across all hubs" —
-    # but it only calls self.async_refresh(), i.e. the SAME
-    # _async_update_data() as an ordinary poll tick, so it inherits the
-    # #194 throttle verbatim and can still trigger the full video/smart-lock
-    # fan-out it claims to avoid.
-    assert coord.api.async_get_video_edges.await_count == 1
-    assert coord.api.async_get_smart_locks.await_count == 1
+    # realtime_active is still True. Before plan 009, that combination —
+    # armed-looking space + cycle landing on the Nth tick — was what forced
+    # the "light" refresh to do the full fan-out anyway (plan 008's
+    # BASELINE). async_force_state_refresh() now sets _light_refresh_pending
+    # before calling async_refresh(), which _async_update_data() consumes to
+    # skip the fan-out unconditionally — neither the throttle's modulo NOR
+    # realtime_active gets a vote once a refresh is flagged "light".
+    assert coord.api.async_get_video_edges.await_count == 0
+    assert coord.api.async_get_smart_locks.await_count == 0
+    # The light refresh also does not advance the throttle's cadence.
+    assert coord._cycle_counter == coord._realtime_skip_factor - 1
     assert space.security_state == SecurityState.DISARMED  # applied AFTER the refresh
 
 
-async def test_force_state_refresh_increments_cycle_counter() -> None:
-    """An out-of-band forced refresh is not free: it consumes a throttle cycle."""
+async def test_force_state_refresh_does_not_touch_cycle_counter() -> None:
+    """An out-of-band forced (light) refresh does not consume a throttle cycle (plan 009)."""
     coord = _coordinator(SecurityState.ARMED)
-    assert coord._cycle_counter == 0
+    coord._cycle_counter = 5
 
     await coord.async_force_state_refresh()
 
-    # BASELINE (plan 009): async_force_state_refresh() drives the same
-    # _cycle_counter used by the #194 armed-aware throttle, so a realtime
-    # event shifts the phase of the ordinary polling cadence instead of
-    # being a side-channel that leaves it alone.
-    assert coord._cycle_counter == 1
+    # async_force_state_refresh() sets _light_refresh_pending, which
+    # _async_update_data() consumes to skip the _cycle_counter increment —
+    # a realtime event no longer shifts the phase of the #194 armed-aware
+    # throttle's ordinary polling cadence.
+    assert coord._cycle_counter == 5
+
+
+async def test_light_refresh_with_forced_metadata_still_fans_out() -> None:
+    """need_metadata_refresh keeps priority over a light refresh's skip (plan 009)."""
+    coord = _coordinator(SecurityState.ARMED)
+    coord.sqs_manager = MagicMock()  # realtime manager present — would normally throttle
+    coord._force_metadata_refresh = True
+
+    await coord.async_force_state_refresh()
+
+    # A light refresh alone would skip the fan-out (see
+    # test_disarm_event_light_refresh_skips_video_and_locks above), but an
+    # explicit account-wide metadata refresh — requested independently of
+    # this being a "light" refresh — still forces it, exactly like an
+    # ordinary hourly/forced metadata tick would.
+    assert coord.api.async_get_video_edges.await_count == 1
+    assert coord.api.async_get_smart_locks.await_count == 1
+    assert coord._force_metadata_refresh is False  # consumed by this tick
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_event_refresh_budget.py
+++ b/tests/test_event_refresh_budget.py
@@ -1,0 +1,449 @@
+"""Characterize the REST call budget on the event -> refresh path.
+
+Three optimisations of the API call budget were merged recently (#192 skip
+of smart-lock detail, #193 light refresh after a realtime event, #194
+armed-aware cadence). They interact across the boundary between the
+SSE/SQS managers and the coordinator, but no existing test exercises that
+boundary end to end: each side mocks the other entirely
+(``async_force_state_refresh = AsyncMock()`` on the manager side,
+``async_refresh = AsyncMock()`` / ``_async_update_data`` mocked wholesale on
+the coordinator side). These tests instead build a REAL
+``AjaxDataCoordinator`` (via ``object.__new__``, no live ``hass`` /
+``DataUpdateCoordinator`` machinery) and a REAL ``SQSManager`` wired to it,
+and count the actual REST calls (or the real coordinator-tick methods)
+produced by simulated events.
+
+They are characterization tests: they pin today's behaviour, defects
+included, with the defect spelled out in a comment on the assertion that
+documents it. Plans 009 (light-refresh contract), 010 (bypass single-miss)
+and 011 (burst coalescing) each tighten one of the assertions marked
+``# BASELINE`` below — that is expected and will require updating this
+file, not a regression in it.
+
+The only mocked "bridge" in the coordinator builder is ``async_refresh``
+itself, which stands in for ``DataUpdateCoordinator``'s real
+``async_refresh`` (never initialised here, since ``__init__`` is bypassed)
+but forwards straight into the REAL ``_async_update_data()`` — exactly what
+``async_force_metadata_refresh`` / ``async_force_state_refresh`` do in
+production (they just call ``self.async_refresh()``). Everything else
+exercised here — throttle math, cycle counter, event dispatch, dedup — is
+the genuine production code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.ajax.api import AjaxRestApi
+from custom_components.ajax.const import UPDATE_INTERVAL
+from custom_components.ajax.coordinator import AjaxDataCoordinator
+from custom_components.ajax.models import (
+    AjaxAccount,
+    AjaxSmartLock,
+    AjaxSpace,
+    AjaxVideoEdge,
+    SecurityState,
+    VideoEdgeType,
+)
+from custom_components.ajax.sqs_manager import SQSManager
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _account_with_space(security_state: SecurityState) -> AjaxAccount:
+    """An account with one space that already has a video edge + smart lock.
+
+    Both devices are pre-existing (their ids match the canned API returns
+    configured on the coordinator below) so a tick never hits the
+    "new device" / "removed device" branches, which would need a real HA
+    device registry — out of scope for a REST-call-budget test.
+    """
+    space = AjaxSpace(
+        id="s1",
+        name="Home",
+        hub_id="hub1",
+        real_space_id="rs1",
+        security_state=security_state,
+    )
+    space.video_edges["ve1"] = AjaxVideoEdge(
+        id="ve1",
+        name="Cam",
+        space_id="s1",
+        video_edge_type=VideoEdgeType.BULLET,
+        connection_state="ONLINE",
+    )
+    space.smart_locks["sl1"] = AjaxSmartLock(
+        id="sl1",
+        name="Lock",
+        space_id="s1",
+        raw_data={"id": "sl1", "name": "Lock"},
+    )
+    account = AjaxAccount(user_id="u1", name="user", email="u@example.com")
+    account.spaces["s1"] = space
+    return account
+
+
+def _coordinator(security_state: SecurityState = SecurityState.ARMED) -> AjaxDataCoordinator:
+    """Bare coordinator (``object.__new__``) with a REAL ``_async_update_data``.
+
+    Modelled on ``tests/test_coordinator_core_coverage.py::_coordinator()``,
+    extended with:
+    - a pre-populated account (one armed-capable space with a video edge and
+      a smart lock) so the light-tick fan-out branch has something to do;
+    - canned ``coord.api.async_get_video_edges`` / ``async_get_smart_locks``
+      so the REAL (unmocked) ``_async_update_video_edges`` /
+      ``_async_update_smart_locks`` coordinator methods can run for real and
+      the resulting REST-call counts are meaningful;
+    - the extra attributes ``sqs_manager.py`` handlers touch directly
+      (``_skipped_state_change_hubs``, ``_event_entities``, ...) and mocks
+      for the coordinator hooks those handlers call
+      (``has_pending_ha_action``, ``_create_sqs_notification``, ...) so a
+      real ``SQSManager`` can be wired to this coordinator (see
+      ``_make_manager`` below) without touching AWS or a real event loop.
+
+    ``_async_update_spaces_from_hubs`` / ``_async_update_devices`` stay
+    mocked at the coordinator-method level, exactly like the reference
+    tests in ``test_coordinator_core_coverage.py`` — they are not part of
+    the video/smart-lock REST budget this file measures, and running them
+    for real would require reproducing the whole hubs/rooms/users/groups
+    REST surface for no benefit here.
+    """
+    coord = object.__new__(AjaxDataCoordinator)
+    coord.api = MagicMock()
+    coord.hass = MagicMock()
+    coord.config_entry = MagicMock()
+    coord.account = _account_with_space(security_state)
+
+    # Real-time managers (None by default — set per-test).
+    coord.sqs_manager = None
+    coord.sse_manager = None
+    coord.onvif_manager = None
+
+    # Polling state.
+    coord._initial_load_done = True
+    coord._force_metadata_refresh = False
+    coord._bypass_cache_next_refresh = False
+    coord._cycle_counter = 0
+    coord._realtime_skip_factor = 3
+    coord._last_metadata_refresh = 1e18  # far future -> no metadata refresh
+    coord._door_sensor_poll_task = None
+    coord._door_sensor_poll_security_state = SecurityState.DISARMED
+    coord._door_sensor_fast_poll_enabled = False
+    coord._sse_url = None
+    coord._sqs_initialized = False
+    coord._sqs_init_in_progress = False
+    coord._aws_access_key_id = None
+    coord._onvif_initialized = False
+    coord._onvif_reconcile_in_progress = False
+    coord._onvif_last_bootstrap_attempt = 0.0
+
+    # Auth resilience.
+    coord._consecutive_auth_errors = 0
+    coord._max_auth_errors = 3
+
+    # Diagnostics counters.
+    coord.stats = {
+        "events_sse_received": 0,
+        "events_sqs_received": 0,
+        "events_onvif_received": 0,
+        "auth_errors": 0,
+        "discovery_refreshes": 0,
+    }
+
+    # DataUpdateCoordinator-provided attributes _async_update_data reads.
+    coord.last_update_success = True
+    coord.update_interval = timedelta(seconds=UPDATE_INTERVAL)
+
+    # api shape _async_update_data inspects.
+    coord.api.is_proxy_mode = False
+    coord.api.suggested_interval = None
+    coord.api.bypass_cache_next = MagicMock()
+
+    # Out of scope for this file's REST budget — mocked at the
+    # coordinator-method level (see docstring above).
+    coord._async_update_spaces_from_hubs = AsyncMock()
+    coord._async_update_devices = AsyncMock()
+    coord._async_update_notifications = AsyncMock()
+    coord._async_restore_smart_locks = AsyncMock()
+    coord._async_cleanup_stale_devices = MagicMock()
+    coord._manage_door_sensor_polling = MagicMock()
+    coord._reset_expired_motion_detections = MagicMock()
+
+    # REAL (unmocked, inherited from AjaxStateUpdaterMixin) — these call
+    # straight through to coord.api.async_get_video_edges /
+    # async_get_smart_locks, the exact REST boundary this file measures.
+    coord.api.async_get_video_edges = AsyncMock(
+        return_value=[
+            {
+                "id": "ve1",
+                "type": "BULLET",
+                "name": "Cam",
+                "networkInterface": {},
+                "firmware": {},
+                "connectionState": "ONLINE",
+                "channels": [],
+            }
+        ]
+    )
+    coord.api.async_get_smart_locks = AsyncMock(return_value=[{"id": "sl1", "name": "Lock"}])
+
+    # Attributes/hooks sqs_manager.py's handlers touch directly on the
+    # coordinator, needed even though _async_update_spaces_from_hubs is
+    # mocked (see tests/test_sqs_manager_coverage.py::_make_coordinator()).
+    coord._skipped_state_change_hubs = set()
+    coord._event_entities = {}
+    coord.entry_id = "entry1"
+    coord.has_pending_ha_action = MagicMock(return_value=False)
+    coord._create_sqs_notification = AsyncMock()
+    coord._async_save_smart_locks = AsyncMock()
+    coord._fire_security_state_event = MagicMock()
+    coord._update_polling_interval = MagicMock()
+    coord.async_set_updated_data = MagicMock()
+    coord._escape_markdown = lambda s: s
+    coord.async_request_refresh = AsyncMock()
+    coord.hass.loop.call_later = MagicMock(return_value=MagicMock())
+
+    # Close any coroutine handed to async_create_task so it doesn't leak a
+    # "coroutine was never awaited" warning when a handler spawns background
+    # work (e.g. _async_save_smart_locks).
+    create_task = MagicMock()
+
+    def _consume(coro: Any = None, *args: Any, **kwargs: Any) -> MagicMock:
+        if coro is not None and hasattr(coro, "close"):
+            coro.close()
+        return MagicMock()
+
+    create_task.side_effect = _consume
+    coord.hass.async_create_task = create_task
+    coord.hass.bus.async_fire = MagicMock()
+
+    # The one mocked "bridge": stands in for DataUpdateCoordinator's real
+    # async_refresh() (never initialised — __init__ is bypassed) but
+    # forwards into the REAL _async_update_data(), same as
+    # async_force_metadata_refresh/async_force_state_refresh do in
+    # production (coordinator.py:290-313).
+    async def _fake_async_refresh() -> None:
+        coord.account = await coord._async_update_data()
+
+    coord.async_refresh = _fake_async_refresh
+
+    return coord
+
+
+def _make_manager(coordinator: AjaxDataCoordinator) -> SQSManager:
+    """Build a REAL SQSManager (bypassing __init__) wired to ``coordinator``.
+
+    Modelled on tests/test_sqs_manager_coverage.py::_make_manager(), except
+    ``coordinator`` is a real AjaxDataCoordinator (see ``_coordinator()``
+    above) instead of a MagicMock — the whole point of this file is to
+    exercise the real manager -> real coordinator boundary.
+    """
+    mgr = object.__new__(SQSManager)
+    mgr.coordinator = coordinator
+    mgr.sqs_client = MagicMock()
+    mgr._enabled = True
+    mgr._last_event_time = 0.0
+    mgr._last_state_update = {}
+    mgr._recent_event_ids = {}
+    mgr._language = "en"
+    mgr._last_discovery_refresh = 0.0
+    mgr._pending_timers = set()
+    mgr._background_tasks = set()
+    mgr._security_event_lock = asyncio.Lock()
+    return mgr
+
+
+def _sqs_event(
+    event_tag: str, source_id: str = "grp", timestamp: int = 1700000000000, **overrides: Any
+) -> dict[str, Any]:
+    """Minimal SQS event_data envelope (modelled on the _event() helper in
+    tests/test_sqs_manager_coverage.py).
+    """
+    event = {
+        "eventTag": event_tag,
+        "eventTypeV2": "SECURITY",
+        "eventCode": "",
+        "hubId": "hub1",
+        "hubName": "Hub",
+        "sourceObjectName": "Group",
+        "sourceObjectType": "GROUP",
+        "sourceObjectId": source_id,
+        "sourceRoomName": "",
+        "timestamp": timestamp,
+        "transition": "",
+        "additionalDataV2": [],
+    }
+    event.update(overrides)
+    return {"event": event}
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — smoke test: the real _async_update_data() runs end to end
+# ---------------------------------------------------------------------------
+
+
+async def test_periodic_tick_runs_real_update_data_pipeline() -> None:
+    """A bare periodic tick runs the REAL _async_update_data() to completion."""
+    coord = _coordinator(SecurityState.DISARMED)
+
+    result = await coord._async_update_data()
+
+    assert result is coord.account
+    assert coord._cycle_counter == 1
+    # No realtime manager + disarmed -> the light-tick optimisation never
+    # applies (correct, existing behaviour — not a BASELINE finding): video
+    # edges and smart locks are polled every cycle via the real REST calls.
+    coord.api.async_get_video_edges.assert_awaited_once_with("rs1")
+    coord.api.async_get_smart_locks.assert_awaited_once_with("rs1", known_ids={"sl1"})
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — a real SQS event drives the real coordinator tick
+# ---------------------------------------------------------------------------
+
+
+async def test_sqs_arm_event_triggers_real_coordinator_tick(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An 'arm' event routed through the real manager runs a real coordinator tick."""
+    monkeypatch.setattr("custom_components.ajax.sqs_manager.asyncio.sleep", AsyncMock())
+    coord = _coordinator(SecurityState.DISARMED)
+    mgr = _make_manager(coord)
+    coord.sqs_manager = mgr
+    space = coord.account.spaces["s1"]
+
+    result = await mgr._handle_security_event(space, "arm", "John", "USER")
+
+    assert result is True
+    # Proof the REAL _async_update_data() ran (not a mocked bridge):
+    # _async_update_devices is unconditional every tick, so one await means
+    # one real pass through the coordinator's periodic-update branch.
+    coord._async_update_devices.assert_awaited_once_with("s1")
+    assert coord._cycle_counter == 1
+    assert space.security_state == SecurityState.ARMED
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — BASELINE: manager -> coordinator boundary defects
+# ---------------------------------------------------------------------------
+
+
+async def test_group_event_burst_runs_one_tick_per_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Three distinct group-arm events in a row each run their own full tick."""
+    monkeypatch.setattr("custom_components.ajax.sqs_manager.asyncio.sleep", AsyncMock())
+    coord = _coordinator(SecurityState.ARMED)
+    mgr = _make_manager(coord)
+    coord.sqs_manager = mgr
+
+    for idx, group_id in enumerate(("g1", "g2", "g3")):
+        handled = await mgr._handle_event(_sqs_event("grouparm", source_id=group_id, timestamp=1700000000000 + idx))
+        assert handled is True
+
+    # BASELINE (plan 011): no coalescing across the burst — 3 independent
+    # group-arm events produce 3 independent _async_update_data() ticks
+    # (each with its own 1.0s internal sleep, here patched to no-op), even
+    # though group states are already refetched on every tick (#150) and a
+    # single coalesced refresh would have been enough.
+    assert coord._async_update_devices.await_count == 3
+    assert coord._cycle_counter == 3
+
+
+async def test_disarm_event_light_refresh_fetches_video_and_locks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A realtime-triggered 'light' refresh can still do the full REST fan-out."""
+    monkeypatch.setattr("custom_components.ajax.sqs_manager.asyncio.sleep", AsyncMock())
+    coord = _coordinator(SecurityState.ARMED)
+    # Land the upcoming tick on the Nth cycle of the #194 throttle.
+    coord._cycle_counter = coord._realtime_skip_factor - 1
+    mgr = _make_manager(coord)
+    coord.sqs_manager = mgr
+    space = coord.account.spaces["s1"]
+
+    result = await mgr._handle_security_event(space, "disarm", "John", "USER")
+
+    assert result is True
+    # sqs_manager._handle_security_event calls async_force_state_refresh()
+    # *before* it mutates space.security_state (the "if state_changed..."
+    # assignment is textually after the "if is_group_event or
+    # is_full_arm_disarm" block, sqs_manager.py:459-499) — so at the moment
+    # _async_update_data() actually runs, the space still reports ARMED and
+    # realtime_active is still True. What forces the fetch below is the
+    # Nth-cycle sync cadence set up above, not "disarmed -> poll every
+    # cycle" (that path is covered by test_periodic_tick_... instead).
+    #
+    # BASELINE (plan 009): async_force_state_refresh's docstring promises a
+    # refresh "WITHOUT ... rooms/users/video re-fetches across all hubs" —
+    # but it only calls self.async_refresh(), i.e. the SAME
+    # _async_update_data() as an ordinary poll tick, so it inherits the
+    # #194 throttle verbatim and can still trigger the full video/smart-lock
+    # fan-out it claims to avoid.
+    assert coord.api.async_get_video_edges.await_count == 1
+    assert coord.api.async_get_smart_locks.await_count == 1
+    assert space.security_state == SecurityState.DISARMED  # applied AFTER the refresh
+
+
+async def test_force_state_refresh_increments_cycle_counter() -> None:
+    """An out-of-band forced refresh is not free: it consumes a throttle cycle."""
+    coord = _coordinator(SecurityState.ARMED)
+    assert coord._cycle_counter == 0
+
+    await coord.async_force_state_refresh()
+
+    # BASELINE (plan 009): async_force_state_refresh() drives the same
+    # _cycle_counter used by the #194 armed-aware throttle, so a realtime
+    # event shifts the phase of the ordinary polling cadence instead of
+    # being a side-channel that leaves it alone.
+    assert coord._cycle_counter == 1
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — BASELINE: the proxy-cache bypass window at the API layer
+# ---------------------------------------------------------------------------
+
+
+def _space_payload() -> dict[str, Any]:
+    return {
+        "devices": [
+            {"id": "v1", "type": "VIDEO_EDGE"},
+            {"id": "l1", "type": "SMART_LOCK"},
+        ]
+    }
+
+
+async def test_bypass_window_double_space_fetch() -> None:
+    """Inside a bypass_cache_next() window, the space payload is fetched twice."""
+    api = AjaxRestApi(api_key="k", email="u@example.com", password="p")
+    api.user_id = "u1"
+    api._request = AsyncMock(return_value=_space_payload())  # type: ignore[method-assign]
+
+    api.bypass_cache_next()
+    await api.async_get_video_edges("s1")
+    await api.async_get_smart_locks("s1", known_ids={"l1"})
+
+    space_fetches = [call for call in api._request.await_args_list if call.args[:2] == ("GET", "user/u1/spaces/s1")]
+    # BASELINE (plan 010): bypass_cache_next() opens a blanket 2s window
+    # during which _cache_bypass_active() is True for every caller — both
+    # async_get_video_edges and async_get_smart_locks re-fetch the same
+    # space payload instead of the second one reusing the first's result.
+    assert len(space_fetches) == 2
+
+
+async def test_no_bypass_window_single_space_fetch() -> None:
+    """Twin of the bypass test: outside a bypass window, the cache coalesces.
+
+    This is nominal, already-correct behaviour — it must keep holding once
+    plan 010 tightens the bypass-window test above.
+    """
+    api = AjaxRestApi(api_key="k", email="u@example.com", password="p")
+    api.user_id = "u1"
+    api._request = AsyncMock(return_value=_space_payload())  # type: ignore[method-assign]
+
+    await api.async_get_video_edges("s1")
+    await api.async_get_smart_locks("s1", known_ids={"l1"})
+
+    space_fetches = [call for call in api._request.await_args_list if call.args[:2] == ("GET", "user/u1/spaces/s1")]
+    assert len(space_fetches) == 1

--- a/tests/test_event_refresh_budget.py
+++ b/tests/test_event_refresh_budget.py
@@ -25,9 +25,14 @@ Plan 009 has landed: ``async_force_state_refresh()`` now sets
 ``_async_update_data()`` consumes that flag to skip both the
 ``_cycle_counter`` increment and the video/smart-lock fan-out
 unconditionally. The tests that used to carry a plan-009 baseline marker
-now assert the fixed (no fan-out / no counter drift) behaviour instead;
-only the plan 010 (bypass single-miss) and plan 011 (burst coalescing)
-BASELINE assertions remain open.
+now assert the fixed (no fan-out / no counter drift) behaviour instead.
+
+Plan 010 has also landed: ``api/_base.py``'s ``bypass_cache_next()`` now
+records when the window opened (``_bypass_cache_opened_at``), and
+``_cache_entry_usable()`` only rejects entries written before that instant
+— a fetch done inside the window is still reused by the next same-tick
+caller. Only the plan 011 (burst coalescing) BASELINE assertion remains
+open.
 
 The only mocked "bridge" in the coordinator builder is ``async_refresh``
 itself, which stands in for ``DataUpdateCoordinator``'s real
@@ -436,7 +441,7 @@ async def test_light_refresh_with_forced_metadata_still_fans_out() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Step 4 — BASELINE: the proxy-cache bypass window at the API layer
+# Step 4 — the proxy-cache bypass window at the API layer
 # ---------------------------------------------------------------------------
 
 
@@ -449,8 +454,8 @@ def _space_payload() -> dict[str, Any]:
     }
 
 
-async def test_bypass_window_double_space_fetch() -> None:
-    """Inside a bypass_cache_next() window, the space payload is fetched twice."""
+async def test_bypass_window_single_space_fetch() -> None:
+    """Inside a bypass_cache_next() window, the space payload is fetched once (plan 010)."""
     api = AjaxRestApi(api_key="k", email="u@example.com", password="p")
     api.user_id = "u1"
     api._request = AsyncMock(return_value=_space_payload())  # type: ignore[method-assign]
@@ -460,18 +465,19 @@ async def test_bypass_window_double_space_fetch() -> None:
     await api.async_get_smart_locks("s1", known_ids={"l1"})
 
     space_fetches = [call for call in api._request.await_args_list if call.args[:2] == ("GET", "user/u1/spaces/s1")]
-    # BASELINE (plan 010): bypass_cache_next() opens a blanket 2s window
-    # during which _cache_bypass_active() is True for every caller — both
-    # async_get_video_edges and async_get_smart_locks re-fetch the same
-    # space payload instead of the second one reusing the first's result.
-    assert len(space_fetches) == 2
+    # async_get_video_edges' fetch lands INSIDE the bypass window it opened,
+    # so it is fresh: async_get_smart_locks' own async_get_space() call
+    # reuses it (_cache_entry_usable()) instead of re-fetching the same
+    # space payload a few milliseconds later.
+    assert len(space_fetches) == 1
 
 
 async def test_no_bypass_window_single_space_fetch() -> None:
     """Twin of the bypass test: outside a bypass window, the cache coalesces.
 
-    This is nominal, already-correct behaviour — it must keep holding once
-    plan 010 tightens the bypass-window test above.
+    Same outcome (1 fetch) as the bypass-window test above, for a different
+    reason: no window is open at all, so the plain TTL cache coalesces the
+    two callers — nominal behaviour that must keep holding.
     """
     api = AjaxRestApi(api_key="k", email="u@example.com", password="p")
     api.user_id = "u1"

--- a/tests/test_sqs_manager_coverage.py
+++ b/tests/test_sqs_manager_coverage.py
@@ -48,6 +48,7 @@ def _make_coordinator() -> MagicMock:
     coord.stats = {"events_sqs_received": 0, "discovery_refreshes": 0}
     coord._skipped_state_change_hubs = set()
     coord._event_entities = {}
+    coord._last_forced_state_refresh_started = 0.0
     coord.config_entry = SimpleNamespace(options={})
     # Async coordinator hooks
     coord.has_pending_ha_action = MagicMock(return_value=False)
@@ -366,6 +367,50 @@ async def test_handle_security_event_unknown_tag_returns_false() -> None:
     mgr = _make_manager()
     space = _space()
     assert await mgr._handle_security_event(space, "bogus", "John") is False
+
+
+# ---------------------------------------------------------------------------
+# _handle_security_event — burst coalescing (plan 011)
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_security_event_coalesced_skips_refresh_sequence(monkeypatch) -> None:
+    """A refresh that started AFTER this event's own reception already covers
+    it - the skip-set/sleep/bypass-flag/refresh sequence must not run again
+    for this event (multi-group "arm all" bursts emit one event per group)."""
+    mgr = _make_manager()
+    monkeypatch.setattr("custom_components.ajax.sqs_manager.asyncio.sleep", AsyncMock())
+    mgr.coordinator._bypass_cache_next_refresh = False
+    mgr.coordinator._last_forced_state_refresh_started = time.time() + 5  # "started" in the future
+    space = _space(SecurityState.DISARMED)
+
+    result = await mgr._handle_security_event(space, "arm", "John", "USER")
+
+    assert result is True
+    mgr.coordinator.async_force_state_refresh.assert_not_awaited()
+    # Neither the skip-set nor the bypass-cache flag may be touched by a
+    # coalesced event (they belong to the refresh that already covers it).
+    assert mgr.coordinator._bypass_cache_next_refresh is False
+    assert "hub1" not in mgr.coordinator._skipped_state_change_hubs
+    # Per-event notification / history / bus-event handling still runs
+    # unconditionally, even when the refresh itself is coalesced away.
+    mgr.coordinator._create_sqs_notification.assert_awaited_once()
+    mgr.coordinator._fire_security_state_event.assert_called_once()
+
+
+async def test_handle_security_event_not_coalesced_when_no_refresh_started_yet(monkeypatch) -> None:
+    """_last_forced_state_refresh_started defaults to 0.0 - today's full
+    sleep+refresh sequence still runs for the first event of a burst."""
+    mgr = _make_manager()
+    monkeypatch.setattr("custom_components.ajax.sqs_manager.asyncio.sleep", AsyncMock())
+    assert mgr.coordinator._last_forced_state_refresh_started == 0.0
+    space = _space(SecurityState.DISARMED)
+
+    result = await mgr._handle_security_event(space, "arm", "John", "USER")
+
+    assert result is True
+    mgr.coordinator.async_force_state_refresh.assert_awaited_once()
+    assert mgr.coordinator._bypass_cache_next_refresh is True
 
 
 async def test_handle_security_event_ha_pending_skips_state_update(monkeypatch) -> None:

--- a/tests/test_sse_manager_coverage.py
+++ b/tests/test_sse_manager_coverage.py
@@ -62,6 +62,7 @@ def _make_manager() -> SSEManager:
         _event_entities={},
         _skipped_state_change_hubs=set(),
         _bypass_cache_next_refresh=False,
+        _last_forced_state_refresh_started=0.0,
         has_pending_ha_action=MagicMock(return_value=False),
         async_set_updated_data=MagicMock(),
         async_request_refresh=AsyncMock(),
@@ -383,6 +384,64 @@ async def test_security_event_refresh_failure_applies_fallback_state() -> None:
     mgr.coordinator.async_force_state_refresh = AsyncMock(side_effect=RuntimeError("api down"))
     await mgr._handle_security_event(space, "arm", "User", "USER")
     # Fallback applied the new state because refresh failed and state changed.
+    assert space.security_state == SecurityState.ARMED
+    assert "hub1" in mgr._last_state_update
+
+
+# ---------------------------------------------------------------------------
+# _handle_security_event — burst coalescing (plan 011)
+# ---------------------------------------------------------------------------
+
+
+async def test_security_event_coalesced_skips_refresh_sequence() -> None:
+    """A refresh that started AFTER this event's own reception already covers
+    it - the skip-set/sleep/bypass-flag/refresh/fallback sequence must not
+    run again for this event (multi-group "arm all" bursts emit one event
+    per group)."""
+    mgr = _make_manager()
+    space = _space(SecurityState.DISARMED)
+    mgr.coordinator._bypass_cache_next_refresh = False
+    mgr.coordinator._last_forced_state_refresh_started = time.time() + 5  # "started" in the future
+
+    await mgr._handle_security_event(space, "arm", "User", "USER")
+
+    mgr.coordinator.async_force_state_refresh.assert_not_awaited()
+    # Neither the skip-set nor the bypass-cache flag may be touched by a
+    # coalesced event (they belong to the refresh that already covers it).
+    assert mgr.coordinator._bypass_cache_next_refresh is False
+    assert "hub1" not in mgr.coordinator._skipped_state_change_hubs
+    # Per-event notification / history / bus-event handling still runs
+    # unconditionally, even when the refresh itself is coalesced away.
+    mgr.coordinator._create_sqs_notification.assert_awaited_once()
+    mgr.coordinator._fire_security_state_event.assert_called_once()
+
+
+async def test_security_event_not_coalesced_when_no_refresh_started_yet() -> None:
+    """_last_forced_state_refresh_started defaults to 0.0 - today's full
+    sleep+refresh sequence still runs for the first event of a burst."""
+    mgr = _make_manager()
+    space = _space(SecurityState.DISARMED)
+    assert mgr.coordinator._last_forced_state_refresh_started == 0.0
+
+    await mgr._handle_security_event(space, "arm", "User", "USER")
+
+    mgr.coordinator.async_force_state_refresh.assert_awaited_once()
+    assert mgr.coordinator._bypass_cache_next_refresh is True
+
+
+async def test_security_event_fallback_still_applies_when_not_coalesced() -> None:
+    """Pinned explicitly against a regression from the coalescing
+    short-circuit: a NON-coalesced event (_last_forced_state_refresh_started
+    predates it) whose refresh fails still applies the SSE fallback state,
+    exactly like test_security_event_refresh_failure_applies_fallback_state."""
+    mgr = _make_manager()
+    space = _space(SecurityState.DISARMED)
+    mgr.coordinator._last_forced_state_refresh_started = 0.0
+    mgr.coordinator.async_force_state_refresh = AsyncMock(side_effect=RuntimeError("api down"))
+
+    await mgr._handle_security_event(space, "arm", "User", "USER")
+
+    mgr.coordinator.async_force_state_refresh.assert_awaited_once()  # refresh WAS attempted
     assert space.security_state == SecurityState.ARMED
     assert "hub1" in mgr._last_state_update
 


### PR DESCRIPTION
Four stacked commits (one per implementation plan) reducing the REST call budget on the event → refresh path. The three merged optimisations (#192/#193/#194) interacted badly once combined; this PR pins the boundary with real integration tests, then fixes each interaction.

1. **test(coordinator)**: new `tests/test_event_refresh_budget.py` — a REAL `AjaxDataCoordinator` wired to a REAL `SQSManager`, counting the actual REST calls produced by simulated events (this boundary was previously mock-on-both-sides).
2. **fix(coordinator)**: `async_force_state_refresh` now honors its own docstring — a light refresh no longer advances the #194 throttle cadence and never runs the video-edge/smart-lock fan-out (an explicit metadata refresh still does).
3. **perf(api)**: the 2s cache-bypass window now forces at most ONE fresh fetch per key; same-tick callers (`async_get_video_edges` + `async_get_smart_locks` reading the same space) reuse the fresh entry instead of double-fetching `GET /spaces/{id}`.
4. **perf(realtime)**: multi-group "arm all" bursts (one event per group, delivered concurrently by the SQS/SSE clients) now coalesce into a single forced refresh instead of N sequential full ticks. Per-event notifications/history/bus events are unchanged; the #133 duplicate-suppression and the SSE failure fallback are preserved and covered by dedicated tests.

Merge with **rebase** to keep the four commits individual.

1958 tests green, mypy --strict 0 errors, coverage 99%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)