### PR TITLE
ci: pip cache + concurrency groups, Makefile, mypy pre-push hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
@@ -20,6 +24,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.14.6"
+          cache: pip
+          cache-dependency-path: requirements_test.txt
 
       - name: Install dependencies
         run: pip install ruff bandit codespell
@@ -55,6 +61,8 @@ jobs:
           # (pytest-homeassistant-custom-component) and recent Home Assistant
           # releases require it, and mypy must parse HA's 3.14 source.
           python-version: "3.14.6"
+          cache: pip
+          cache-dependency-path: requirements_test.txt
 
       - name: Install dependencies
         # mypy only needs itself + homeassistant for stubs — NOT the pytest
@@ -82,6 +90,8 @@ jobs:
           # and the pinned homeassistant in requirements_test.txt require it. The old
           # job pinned 3.12 and failed to install before a single test ran.
           python-version: "3.14.6"
+          cache: pip
+          cache-dependency-path: requirements_test.txt
 
       - name: Install dependencies
         # No editable install: there is no [project]/setup.py to build, and the suite

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "0 0 * * 0"  # Weekly on Sunday
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   hacs:
     name: HACS Action

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   hassfest:
     name: Hassfest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ ci:
   autoupdate_commit_msg: "build: pre-commit autoupdate"
   autofix_commit_msg: "style: pre-commit auto-fix"
   autofix_prs: true
+  skip: [mypy]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -45,3 +46,10 @@ repos:
         entry: sed -i '/Co-Authored-By:.*[Cc]laude/d'
         language: system
         stages: [commit-msg]
+
+      - id: mypy
+        name: mypy (strict, mirrors CI gate)
+        entry: mypy custom_components/ajax/
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+# Mirrors the jobs in .github/workflows/ci.yml. No shared source with CI —
+# if ci.yml changes, update these targets to match.
+
+.PHONY: lint typecheck test coverage check deploy-dev
+
+lint:
+	ruff check .
+	ruff format --check .
+	bandit -r custom_components/ajax/ -c pyproject.toml
+	codespell custom_components/ajax/
+
+typecheck:
+	mypy custom_components/ajax/
+
+test:
+	python -m pytest tests/ -q
+
+coverage:
+	python -m pytest tests/ --cov=custom_components/ajax --cov-report=term-missing
+
+check: lint typecheck test
+
+deploy-dev:
+	sudo rm -rf /home/stephane/homeassistant/config/custom_components/ajax
+	sudo cp -r custom_components/ajax /home/stephane/homeassistant/config/custom_components/
+	sudo chown -R stephane:stephane /home/stephane/homeassistant/config/custom_components/ajax
+	docker restart homeassistant


### PR DESCRIPTION
DX/CI hygiene, no production code touched:

- `concurrency` groups (cancel-in-progress) on ci.yml / hacs.yml / hassfest.yml, `cache: pip` on the three setup-python steps.
- New `Makefile` mirroring the CI jobs exactly: `make lint` / `typecheck` / `test` / `coverage` / `check`, plus `deploy-dev` for the local HA instance.
- pre-commit now runs mypy as a local `pre-push` hook (skipped on pre-commit.ci, where the isolated env has no homeassistant — the CI `typing` job remains the authoritative gate).

Not included (manual follow-up, needs repo admin): the branch ruleset on `main` requiring the Lint / Typing (mypy) / Tests / HACS Action / Hassfest checks — command ready in the implementation plan.

1937 tests green (untouched), workflows YAML-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)