### PR TITLE
refactor: shared raw-devices collector; fix(sensor): 7-language last-event fallback

### DIFF
--- a/custom_components/ajax/_raw_inventory.py
+++ b/custom_components/ajax/_raw_inventory.py
@@ -1,0 +1,116 @@
+"""Shared raw-devices collection for diagnostics and the dump service.
+
+Both ``diagnostics.get_ajax_raw_data`` and ``_services.handle_get_raw_devices``
+walk the same triple loop over ``coordinator.account.spaces`` — devices,
+cameras and video edges, each with a light "list" call followed by a "detail"
+call per item (falling back to the light summary on failure). This module is
+the single place that traversal lives; callers only differ in whether they
+filter by a single device id and how they aggregate/format the result.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .coordinator import AjaxDataCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_collect_raw_inventory(
+    coordinator: AjaxDataCoordinator,
+    target_device_id: str | None = None,
+) -> dict[str, Any]:
+    """Fetch full raw payloads for devices, cameras and video edges.
+
+    ``target_device_id`` filters devices and cameras; video edges are always
+    returned in full (parity with the historical diagnostics behaviour).
+
+    Returns ``{"devices": [...], "cameras": [...], "video_edges": [...],
+    "hub_count": int}``.
+    """
+    all_devices: list[dict[str, Any]] = []
+    all_cameras: list[dict[str, Any]] = []
+    all_video_edges: list[dict[str, Any]] = []
+    hub_count = 0
+
+    if not coordinator.account:
+        return {
+            "devices": all_devices,
+            "cameras": all_cameras,
+            "video_edges": all_video_edges,
+            "hub_count": hub_count,
+        }
+
+    for _space_id, space in coordinator.account.spaces.items():
+        hub_id = space.hub_id
+        if hub_id:
+            hub_count += 1
+            try:
+                # First get device list (light)
+                devices_list = await coordinator.api.async_get_devices(hub_id)
+                # Then get full details for each device
+                for device_summary in devices_list:
+                    device_id = device_summary.get("id")
+                    if target_device_id is not None and target_device_id != device_id:
+                        continue
+                    if device_id:
+                        try:
+                            full_device = await coordinator.api.async_get_device(hub_id, device_id)
+                            all_devices.append(full_device)
+                        except Exception as dev_err:
+                            _LOGGER.warning(
+                                "Failed to get device %s: %s",
+                                device_id,
+                                dev_err,
+                            )
+                            all_devices.append(device_summary)
+            except Exception as err:
+                _LOGGER.error("Failed to get devices for hub %s: %s", hub_id, err)
+
+    # Fetch cameras for each hub (same pattern as devices)
+    for _space_id, space in coordinator.account.spaces.items():
+        hub_id = space.hub_id
+        if hub_id:
+            try:
+                cameras_list = await coordinator.api.async_get_cameras(hub_id)
+                for camera_summary in cameras_list:
+                    camera_id = camera_summary.get("id")
+                    if target_device_id is not None and target_device_id != camera_id:
+                        continue
+                    if camera_id:
+                        try:
+                            full_camera = await coordinator.api.async_get_camera(hub_id, camera_id)
+                            all_cameras.append(full_camera)
+                        except Exception as cam_err:
+                            _LOGGER.warning(
+                                "Failed to get camera %s: %s",
+                                camera_id,
+                                cam_err,
+                            )
+                            all_cameras.append(camera_summary)
+            except Exception as err:
+                _LOGGER.warning("Failed to get cameras for hub %s: %s", hub_id, err)
+
+    # Fetch video edges for each space (requires real_space_id)
+    for _space_id, space in coordinator.account.spaces.items():
+        real_space_id = space.real_space_id
+        if real_space_id:
+            try:
+                video_edges_list = await coordinator.api.async_get_video_edges(real_space_id)
+                all_video_edges.extend(video_edges_list)
+            except Exception as err:
+                _LOGGER.warning(
+                    "Failed to get video edges for space %s: %s",
+                    real_space_id,
+                    err,
+                )
+
+    return {
+        "devices": all_devices,
+        "cameras": all_cameras,
+        "video_edges": all_video_edges,
+        "hub_count": hub_count,
+    }

--- a/custom_components/ajax/_sensor_space.py
+++ b/custom_components/ajax/_sensor_space.py
@@ -28,6 +28,7 @@ from . import AjaxConfigEntry
 from ._ids import device_identifier
 from .const import MANUFACTURER
 from .coordinator import AjaxDataCoordinator
+from .event_codes import EVENT_MESSAGES, get_event_message, resolve_event_language
 from .models import (
     AjaxSpace,
 )
@@ -65,7 +66,48 @@ def format_signal_level(signal: str | None) -> str | None:
     return signal.lower()
 
 
-def format_event_text(event: dict[str, Any]) -> str:
+# Raw SQS/SSE ``action`` strings -> canonical ``event_codes.EVENT_MESSAGES``
+# key. Keys already canonical map to themselves via the ``.get(x, x)`` lookup
+# below, so only the actual aliases need an entry here.
+_ACTION_ALIASES: dict[str, str] = {
+    "arm": "armed",
+    "disarm": "disarmed",
+    "grouparm": "group_armed",
+    "groupdisarm": "group_disarmed",
+    "nightmodeon": "night_mode_on",
+    "nightmodeoff": "night_mode_off",
+    "night_mode": "night_mode_on",
+    "partiallyarmed": "partially_armed",
+    "tampered": "tamper",
+}
+
+# English labels for canonical keys event_codes.EVENT_MESSAGES does not (yet)
+# carry. Must stay in sync with EVENT_MESSAGES' actual coverage — if a key
+# below starts appearing in EVENT_MESSAGES, remove it here (see module notes
+# in plans/015); it would otherwise silently shadow the 7-language table.
+_FALLBACK_EN: dict[str, str] = {
+    "night_mode_on": "Night mode on",
+    "tamper": "Tamper detected",
+    "online": "Device online",
+    "offline": "Device offline",
+    "external_power_on": "Power connected",
+    "external_power_off": "Power disconnected",
+    "glass_break_detected": "Glass break detected",
+}
+
+# Connector word between the message and the user name, by language.
+_BY_WORD: dict[str, str] = {
+    "en": "by",
+    "fr": "par",
+    "es": "por",
+    "de": "von",
+    "nl": "door",
+    "sv": "av",
+    "uk": "від",
+}
+
+
+def format_event_text(event: dict[str, Any], language: str = "en") -> str:
     """Format an SQS event into readable text."""
     event_type = event.get("event_type", "")
     action = event.get("action", "")
@@ -75,48 +117,20 @@ def format_event_text(event: dict[str, Any]) -> str:
     room_name = event.get("room_name")
 
     # Use translated message if available (from SQS/coordinator)
-    # Otherwise fall back to action-based lookup
+    # Otherwise fall back to action-based lookup, translated via
+    # event_codes.EVENT_MESSAGES (the same 7-language table the SSE/SQS
+    # managers already use) with a small English-only residual for the keys
+    # EVENT_MESSAGES doesn't carry yet.
     message = event.get("message")
     if not message:
-        # Fallback: Map actions to English messages
-        action_messages = {
-            # Arming/Disarming (from SQS events)
-            "arm": "Armed",
-            "armed": "Armed",
-            "disarm": "Disarmed",
-            "disarmed": "Disarmed",
-            "grouparm": "Group armed",
-            "group_armed": "Group armed",
-            "groupdisarm": "Group disarmed",
-            "group_disarmed": "Group disarmed",
-            "nightmodeon": "Night mode on",
-            "nightmodeoff": "Night mode off",
-            "night_mode": "Night mode on",
-            "night_mode_on": "Night mode on",
-            "night_mode_off": "Night mode off",
-            "partiallyarmed": "Partially armed",
-            "partially_armed": "Partially armed",
-            # Alarms
-            "motion_detected": "Motion detected",
-            "door_opened": "Door opened",
-            "door_closed": "Door closed",
-            "glass_break_detected": "Glass break detected",
-            "smoke_detected": "Smoke detected",
-            "leak_detected": "Water leak detected",
-            "tamper": "Tamper detected",
-            "tampered": "Tamper detected",
-            "panic": "Panic alarm",
-            # Device status
-            "online": "Device online",
-            "offline": "Device offline",
-            "low_battery": "Low battery",
-            "external_power_on": "Power connected",
-            "external_power_off": "Power disconnected",
-        }
-
-        # Get message from action (case-insensitive)
         action_lower = action.lower() if action else ""
-        message = action_messages.get(action_lower, action or event_type or "Event")
+        canonical = _ACTION_ALIASES.get(action_lower, action_lower)
+        if canonical in EVENT_MESSAGES:
+            message = get_event_message(canonical, language)
+        elif canonical in _FALLBACK_EN:
+            message = _FALLBACK_EN[canonical]
+        else:
+            message = action or event_type or "Event"
 
     parts = [message]
     if device_name and device_name.strip():
@@ -124,26 +138,17 @@ def format_event_text(event: dict[str, Any]) -> str:
     if room_name and room_name.strip():
         parts.append(f"({room_name.strip()})")
     if user_name and user_name.strip():
-        # Use French "par" if message appears to be French, otherwise "by"
-        french_words = (
-            "Armé",
-            "Désarmé",
-            "Groupe",
-            "Mode nuit",
-            "Armement",
-            "Ouverture",
-        )
-        by_word = "par" if any(fw in message for fw in french_words) else "by"
+        by_word = _BY_WORD.get(language, "by")
         parts.append(f"{by_word} {user_name.strip()}")
 
     return " ".join(parts)
 
 
-def get_last_event_text(space: AjaxSpace) -> str:
+def get_last_event_text(space: AjaxSpace, language: str = "en") -> str:
     """Get the last event formatted as text."""
     if not space.recent_events:
         return "no_event"
-    return format_event_text(space.recent_events[0])
+    return format_event_text(space.recent_events[0], language)
 
 
 def get_last_event_attributes(space: AjaxSpace) -> dict[str, Any]:
@@ -448,7 +453,11 @@ class AjaxSpaceSensor(CoordinatorEntity[AjaxDataCoordinator], SensorEntity):
     def native_value(self) -> Any:
         """Return the state of the sensor."""
         space = self.coordinator.get_space(self._space_id)
-        if not space or not self.entity_description.value_fn:
+        if not space:
+            return None
+        if self.entity_description.key == "recent_events":
+            return get_last_event_text(space, resolve_event_language(self.hass.config.language))
+        if not self.entity_description.value_fn:
             return None
         return self.entity_description.value_fn(space)
 

--- a/custom_components/ajax/_services.py
+++ b/custom_components/ajax/_services.py
@@ -29,6 +29,7 @@ from homeassistant.helpers.service import (
     async_extract_referenced_entity_ids,
 )
 
+from ._raw_inventory import async_collect_raw_inventory
 from .const import (
     DOMAIN,
     AjaxConfigEntry,
@@ -194,65 +195,11 @@ async def _async_setup_services(hass: HomeAssistant) -> None:
             coordinator = entry.runtime_data
             if not coordinator.account:
                 continue
-            for _space_id, space in coordinator.account.spaces.items():
-                hub_id = space.hub_id
-                if hub_id:
-                    hub_count += 1
-                    try:
-                        # First get device list (light)
-                        devices_list = await coordinator.api.async_get_devices(hub_id)
-                        # Then get full details for each device
-                        for device_summary in devices_list:
-                            device_id = device_summary.get("id")
-                            if device_id:
-                                try:
-                                    full_device = await coordinator.api.async_get_device(hub_id, device_id)
-                                    all_devices.append(full_device)
-                                except Exception as dev_err:
-                                    _LOGGER.warning(
-                                        "Failed to get device %s: %s",
-                                        device_id,
-                                        dev_err,
-                                    )
-                                    all_devices.append(device_summary)
-                    except Exception as err:
-                        _LOGGER.error("Failed to get devices for hub %s: %s", hub_id, err)
-
-            # Fetch cameras for each hub (same pattern as devices)
-            for _space_id, space in coordinator.account.spaces.items():
-                hub_id = space.hub_id
-                if hub_id:
-                    try:
-                        cameras_list = await coordinator.api.async_get_cameras(hub_id)
-                        for camera_summary in cameras_list:
-                            camera_id = camera_summary.get("id")
-                            if camera_id:
-                                try:
-                                    full_camera = await coordinator.api.async_get_camera(hub_id, camera_id)
-                                    all_cameras.append(full_camera)
-                                except Exception as cam_err:
-                                    _LOGGER.warning(
-                                        "Failed to get camera %s: %s",
-                                        camera_id,
-                                        cam_err,
-                                    )
-                                    all_cameras.append(camera_summary)
-                    except Exception as err:
-                        _LOGGER.warning("Failed to get cameras for hub %s: %s", hub_id, err)
-
-            # Fetch video edges for each space (requires real_space_id)
-            for _space_id, space in coordinator.account.spaces.items():
-                real_space_id = space.real_space_id
-                if real_space_id:
-                    try:
-                        video_edges_list = await coordinator.api.async_get_video_edges(real_space_id)
-                        all_video_edges.extend(video_edges_list)
-                    except Exception as err:
-                        _LOGGER.warning(
-                            "Failed to get video edges for space %s: %s",
-                            real_space_id,
-                            err,
-                        )
+            inventory = await async_collect_raw_inventory(coordinator)
+            all_devices += inventory["devices"]
+            all_cameras += inventory["cameras"]
+            all_video_edges += inventory["video_edges"]
+            hub_count += inventory["hub_count"]
 
         # Write to file (include devices, cameras, and video edges).
         # Redact sensitive fields before writing so the file is safe to share.

--- a/custom_components/ajax/diagnostics.py
+++ b/custom_components/ajax/diagnostics.py
@@ -13,6 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from . import AjaxConfigEntry
+from ._raw_inventory import async_collect_raw_inventory
 from .const import CONF_AUTH_MODE, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -180,10 +181,6 @@ async def get_ajax_raw_data(
     """Get fresh raw data from all devices."""
 
     coordinator = entry.runtime_data
-    all_devices = []
-    all_cameras = []
-    all_video_edges = []
-    hub_count = 0
 
     # Device identifiers are namespaced f"{entry_id}_{ajax_id}" (schema v1.3);
     # strip the prefix so it matches the bare Ajax ids compared against below.
@@ -201,69 +198,11 @@ async def get_ajax_raw_data(
     )
 
     if coordinator.account:
-        for _space_id, space in coordinator.account.spaces.items():
-            hub_id = space.hub_id
-            if hub_id:
-                hub_count += 1
-                try:
-                    # First get device list (light)
-                    devices_list = await coordinator.api.async_get_devices(hub_id)
-                    # Then get full details for each device
-                    for device_summary in devices_list:
-                        device_id = device_summary.get("id")
-                        if target_device_id is not None and target_device_id != device_id:
-                            continue
-                        if device_id:
-                            try:
-                                full_device = await coordinator.api.async_get_device(hub_id, device_id)
-                                all_devices.append(full_device)
-                            except Exception as dev_err:
-                                _LOGGER.warning(
-                                    "Failed to get device %s: %s",
-                                    device_id,
-                                    dev_err,
-                                )
-                                all_devices.append(device_summary)
-                except Exception as err:
-                    _LOGGER.error("Failed to get devices for hub %s: %s", hub_id, err)
-
-        # Fetch cameras for each hub (same pattern as devices)
-        for _space_id, space in coordinator.account.spaces.items():
-            hub_id = space.hub_id
-            if hub_id:
-                try:
-                    cameras_list = await coordinator.api.async_get_cameras(hub_id)
-                    for camera_summary in cameras_list:
-                        camera_id = camera_summary.get("id")
-                        if target_device_id is not None and target_device_id != camera_id:
-                            continue
-                        if camera_id:
-                            try:
-                                full_camera = await coordinator.api.async_get_camera(hub_id, camera_id)
-                                all_cameras.append(full_camera)
-                            except Exception as cam_err:
-                                _LOGGER.warning(
-                                    "Failed to get camera %s: %s",
-                                    camera_id,
-                                    cam_err,
-                                )
-                                all_cameras.append(camera_summary)
-                except Exception as err:
-                    _LOGGER.warning("Failed to get cameras for hub %s: %s", hub_id, err)
-
-        # Fetch video edges for each space (requires real_space_id)
-        for _space_id, space in coordinator.account.spaces.items():
-            real_space_id = space.real_space_id
-            if real_space_id:
-                try:
-                    video_edges_list = await coordinator.api.async_get_video_edges(real_space_id)
-                    all_video_edges.extend(video_edges_list)
-                except Exception as err:
-                    _LOGGER.warning(
-                        "Failed to get video edges for space %s: %s",
-                        real_space_id,
-                        err,
-                    )
+        inventory = await async_collect_raw_inventory(coordinator, target_device_id)
+        all_devices = inventory["devices"]
+        all_cameras = inventory["cameras"]
+        all_video_edges = inventory["video_edges"]
+        hub_count = inventory["hub_count"]
 
         type_counts: dict[str, int] = {}
         for device_data in all_devices:
@@ -279,6 +218,9 @@ async def get_ajax_raw_data(
             "device_types": type_list,
         }
     else:
+        all_devices = []
+        all_cameras = []
+        all_video_edges = []
         summary = {
             "hubs": 0,
             "devices": 0,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -283,6 +283,32 @@ async def test_get_ajax_raw_data_filters_to_target_device_when_set() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_ajax_raw_data_video_edges_ignore_target_device_filter() -> None:
+    """``target_device_id`` filters devices and cameras but never video_edges.
+
+    This is the documented divergence between the two collection call sites
+    (diagnostics filters by device, the raw-devices service does not) — the
+    shared ``async_collect_raw_inventory`` preserves it deliberately, and this
+    test pins it as a contract rather than an accident.
+    """
+    entry, _coord = _coord_with_api_responses(
+        devices=[{"id": "d1", "deviceType": "DoorProtect"}, {"id": "d2", "deviceType": "MotionProtect"}],
+        cameras=[{"id": "d2", "deviceType": "MotionCam"}, {"id": "c1", "deviceType": "Cam"}],
+        video_edges=[{"id": "ve1"}, {"id": "ve2"}],
+    )
+    device = SimpleNamespace(identifiers={(diagnostics.DOMAIN, "entry_test_d2")})
+
+    result = await diagnostics.get_ajax_raw_data(hass=MagicMock(), entry=entry, device=device)
+
+    # Devices and cameras: only the item matching the (namespace-stripped)
+    # target id survives.
+    assert [d["id"] for d in result["devices"]] == ["d2"]
+    assert [c["id"] for c in result["cameras"]] == ["d2"]
+    # Video edges: fetched whole, no per-item filter applied.
+    assert [ve["id"] for ve in result["video_edges"]] == ["ve1", "ve2"]
+
+
+@pytest.mark.asyncio
 async def test_get_ajax_raw_data_returns_zero_summary_without_account() -> None:
     api = MagicMock()
     coord = SimpleNamespace(api=api, account=None)

--- a/tests/test_raw_inventory.py
+++ b/tests/test_raw_inventory.py
@@ -1,0 +1,63 @@
+"""Unit tests for the shared raw-devices collector.
+
+``async_collect_raw_inventory`` is exercised indirectly by
+``tests/test_diagnostics.py`` and ``tests/test_init_coverage.py`` through its
+two callers; these tests pin the module's own contract directly, including
+the defensive "no account" early return that neither caller currently
+triggers (both already guard on ``coordinator.account`` before calling in).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.ajax._raw_inventory import async_collect_raw_inventory
+
+
+def _coordinator(devices=None, cameras=None, video_edges=None, account=True):
+    api = MagicMock()
+    api.async_get_devices = AsyncMock(return_value=[{"id": d["id"]} for d in (devices or [])])
+    api.async_get_device = AsyncMock(side_effect=lambda hub, did: next(d for d in devices if d["id"] == did))
+    api.async_get_cameras = AsyncMock(return_value=[{"id": c["id"]} for c in (cameras or [])])
+    api.async_get_camera = AsyncMock(side_effect=lambda hub, cid: next(c for c in cameras if c["id"] == cid))
+    api.async_get_video_edges = AsyncMock(return_value=video_edges or [])
+    space = SimpleNamespace(hub_id="hub1", real_space_id="real-space-1")
+    coord_account = SimpleNamespace(spaces={"sp1": space}) if account else None
+    return SimpleNamespace(api=api, account=coord_account)
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_inventory_without_account() -> None:
+    coord = _coordinator(account=False)
+    result = await async_collect_raw_inventory(coord)
+    assert result == {"devices": [], "cameras": [], "video_edges": [], "hub_count": 0}
+
+
+@pytest.mark.asyncio
+async def test_collects_devices_cameras_video_edges() -> None:
+    coord = _coordinator(
+        devices=[{"id": "d1", "deviceType": "DoorProtect"}],
+        cameras=[{"id": "c1", "deviceType": "MotionCam"}],
+        video_edges=[{"id": "ve1"}, {"id": "ve2"}],
+    )
+    result = await async_collect_raw_inventory(coord)
+    assert [d["id"] for d in result["devices"]] == ["d1"]
+    assert [c["id"] for c in result["cameras"]] == ["c1"]
+    assert [ve["id"] for ve in result["video_edges"]] == ["ve1", "ve2"]
+    assert result["hub_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_target_device_id_filters_devices_and_cameras_but_not_video_edges() -> None:
+    coord = _coordinator(
+        devices=[{"id": "d1"}, {"id": "d2"}],
+        cameras=[{"id": "d2"}, {"id": "c1"}],
+        video_edges=[{"id": "ve1"}, {"id": "ve2"}],
+    )
+    result = await async_collect_raw_inventory(coord, target_device_id="d2")
+    assert [d["id"] for d in result["devices"]] == ["d2"]
+    assert [c["id"] for c in result["cameras"]] == ["d2"]
+    assert [ve["id"] for ve in result["video_edges"]] == ["ve1", "ve2"]

--- a/tests/test_sensor_binary_coverage.py
+++ b/tests/test_sensor_binary_coverage.py
@@ -33,6 +33,7 @@ from custom_components.ajax.binary_sensor import (
     AjaxVideoEdgeBinarySensor,
     async_setup_entry as binary_async_setup_entry,
 )
+from custom_components.ajax.event_codes import get_event_message
 from custom_components.ajax.models import (
     AjaxDevice,
     AjaxSmartLock,
@@ -111,9 +112,38 @@ def test_format_event_text_unknown_action_falls_back_to_raw() -> None:
 
 
 def test_format_event_text_french_uses_par() -> None:
-    # A French-looking message switches the connector from "by" to "par".
-    text = format_event_text({"message": "Armé", "user_name": "Marie"})
-    assert text == "Armé par Marie"
+    # Expected adaptation: the message-sniffing french_words heuristic is
+    # gone by design (B2) — the connector now comes purely from the
+    # explicit `language` parameter, not from guessing at the message text.
+    text = format_event_text({"action": "arm", "user_name": "Marie"}, language="fr")
+    assert "par" in text
+    assert get_event_message("armed", "fr") in text
+
+
+def test_format_event_text_translates_fallback_dynamically_by_language() -> None:
+    # No hardcoded string for a migrated key — compare against
+    # get_event_message so a future EVENT_MESSAGES wording change can't
+    # silently desync the test from the table it exercises.
+    assert format_event_text({"action": "DISARM"}, language="fr") == get_event_message("disarmed", "fr")
+
+
+def test_format_event_text_de_uses_von() -> None:
+    text = format_event_text({"action": "arm", "user_name": "Otto"}, language="de")
+    assert "von " in text
+    assert "by " not in text
+
+
+def test_format_event_text_uk_uses_vid() -> None:
+    text = format_event_text({"action": "arm", "user_name": "Olena"}, language="uk")
+    assert "від " in text
+
+
+def test_format_event_text_uses_english_only_residual_for_untranslated_keys() -> None:
+    # Keys event_codes.EVENT_MESSAGES doesn't carry yet (see _FALLBACK_EN in
+    # _sensor_space.py) keep their historical English wording regardless of
+    # `language` — they are not part of the 7-language table.
+    assert format_event_text({"action": "tamper"}, language="fr") == "Tamper detected"
+    assert format_event_text({"action": "online"}) == "Device online"
 
 
 def test_get_last_event_text_no_events() -> None:
@@ -228,6 +258,29 @@ def test_space_sensor_device_info_none_when_space_missing() -> None:
     sensor.entity_description = AjaxSpaceSensorDescription(key="x", value_fn=lambda s: 0)
     sensor.coordinator = SimpleNamespace(last_update_success=True, get_space=lambda sid: None)
     assert sensor.device_info is None
+
+
+def test_space_sensor_recent_events_native_value_uses_hass_language() -> None:
+    """``native_value`` for the ``recent_events`` key resolves the real HA
+    language (``self.hass.config.language``), bypassing the English-only
+    lambda in the ``SPACE_SENSORS`` description table.
+    """
+    space = AjaxSpace(id="s1", name="Home", hub_id="hub1", security_state=SecurityState.DISARMED)
+    space.recent_events = [{"action": "arm", "user_name": "Marie"}]
+
+    sensor = object.__new__(AjaxSpaceSensor)
+    sensor._space_id = "s1"
+    # The lambda in SPACE_SENSORS stays as a filet for any other caller —
+    # native_value must not use it for this key, it must take the FR path.
+    sensor.entity_description = AjaxSpaceSensorDescription(
+        key="recent_events", value_fn=lambda s: get_last_event_text(s)
+    )
+    sensor.coordinator = SimpleNamespace(last_update_success=True, get_space=lambda sid: space)
+    sensor.hass = SimpleNamespace(config=SimpleNamespace(language="fr"))
+
+    text = sensor.native_value
+    assert "par" in text
+    assert get_event_message("armed", "fr") in text
 
 
 def _device(online: bool = True, **extra) -> AjaxDevice:


### PR DESCRIPTION
Two commits (merge with **rebase** to keep them separate):

- **refactor**: the ~120-line spaces → devices/cameras/video-edges traversal duplicated between `diagnostics.py` and the `get_raw_devices` service now lives once in `_raw_inventory.py`. The historical quirk (the `target_device_id` filter applies to devices and cameras, never to video edges) is preserved and now pinned by a dedicated test.
- **fix(sensor)**: the last-event sensor's fallback text (used when an event carries no pre-translated `message`) was English-only with a `by`/`par` heuristic. It now goes through `event_codes.get_event_message` — the same 7-language table the SSE/SQS managers already use — with a per-language connector word table. Note: 4 keys change wording in the EN fallback (e.g. `door_opened` → "Opening detected") to align with what the primary path already displays.

1946 tests green, `_sensor_space.py` at 100% coverage, mypy --strict 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)