### PR TITLE
fix(lock): reflect lock/unlock commands immediately instead of waiting for the next poll (#88)

### DIFF
--- a/custom_components/ajax/lock.py
+++ b/custom_components/ajax/lock.py
@@ -3,7 +3,9 @@
 This module creates lock entities for Ajax LockBridge Jeweller devices.
 State comes from the enriched device record (lockStatus / doorStatus) and
 real-time SSE/SQS events. Locking and unlocking are supported via the
-dedicated Ajax ``LOCK_SMART_LOCK`` / ``UNLOCK_SMART_LOCK`` commands.
+dedicated Ajax ``LOCK_SMART_LOCK`` / ``UNLOCK_SMART_LOCK`` commands. A
+successful command also applies an optimistic state update (#88) so HA
+reflects it immediately instead of waiting for the next poll.
 
 Note: Yale cloud locks are automatically filtered out in the coordinator
 since they don't send SSE events and only return minimal API data.
@@ -12,6 +14,7 @@ since they don't send SSE events and only return minimal API data.
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import Any
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockEntity
@@ -132,7 +135,8 @@ class AjaxLock(CoordinatorEntity[AjaxDataCoordinator], LockEntity):
     async def _async_send_lock_command(self, command: str, verb: str) -> None:
         """Send a lock/unlock command to the smart lock.
 
-        No optimistic update: the real state catches up on the next poll / event.
+        On success, applies an optimistic state update so HA reflects the
+        command immediately instead of waiting for the next poll / event.
         """
         space = self.coordinator.get_space(self._space_id)
         smart_lock = self._get_smart_lock()
@@ -153,6 +157,18 @@ class AjaxLock(CoordinatorEntity[AjaxDataCoordinator], LockEntity):
                 translation_key="failed_to_change",
                 translation_placeholders={"entity": smart_lock.name, "error": str(err)},
             ) from err
+
+        # Optimistic update (#88): the physical lock reacts immediately but no
+        # realtime event arrives while disarmed, so without this the HA state
+        # waits for the next poll. Stamping last_event_time reuses the existing
+        # 30s freshness guard in _apply_smart_lock_rest_state, so a stale REST
+        # payload cannot bounce the state back; a real SSE/SQS event or the
+        # first poll after the window remains the final authority.
+        smart_lock.is_locked = command == "LOCK_SMART_LOCK"
+        smart_lock.last_event_tag = f"{verb}_command"
+        smart_lock.last_event_time = datetime.now(UTC)
+        self.async_write_ha_state()
+
         await self.coordinator.async_request_refresh()
 
     @property

--- a/tests/test_lock_select_entities.py
+++ b/tests/test_lock_select_entities.py
@@ -11,12 +11,14 @@ Locking and unlocking both go through the dedicated Ajax
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
+from custom_components.ajax._coordinator_devices import AjaxDevicesMixin
 from custom_components.ajax.lock import AjaxLock
 from custom_components.ajax.models import AjaxDevice, AjaxSmartLock, DeviceType, SecurityState
 from custom_components.ajax.select import (
@@ -40,6 +42,7 @@ def _make_lock(smart_lock: AjaxSmartLock | None, *, hub_id: str | None = "hub1")
         api=SimpleNamespace(async_send_device_command=AsyncMock()),
         async_request_refresh=AsyncMock(),
     )
+    lock.async_write_ha_state = MagicMock()
     return lock
 
 
@@ -113,6 +116,79 @@ async def test_lock_async_unlock_api_error_raises() -> None:
     lock.coordinator.api.async_send_device_command = AsyncMock(side_effect=RuntimeError("boom"))
     with pytest.raises(HomeAssistantError):
         await lock.async_unlock()
+
+
+# ---------------------------------------------------------------------------
+# Optimistic state after a successful lock/unlock command (#88)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lock_async_lock_applies_optimistic_state() -> None:
+    """A successful LOCK_SMART_LOCK reflects immediately instead of waiting for the next poll."""
+    sl = AjaxSmartLock(id="sl1", name="Front Door", space_id="s1")
+    lock = _make_lock(sl)
+    before = datetime.now(UTC)
+
+    await lock.async_lock()
+
+    assert sl.is_locked is True
+    assert sl.last_event_tag == "lock_command"
+    assert sl.last_event_time is not None
+    assert (sl.last_event_time - before).total_seconds() <= 2
+    lock.async_write_ha_state.assert_called_once()
+    lock.coordinator.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_lock_async_unlock_applies_optimistic_state() -> None:
+    """A successful UNLOCK_SMART_LOCK reflects immediately instead of waiting for the next poll."""
+    sl = AjaxSmartLock(id="sl1", name="Front Door", space_id="s1", is_locked=True)
+    lock = _make_lock(sl)
+    before = datetime.now(UTC)
+
+    await lock.async_unlock()
+
+    assert sl.is_locked is False
+    assert sl.last_event_tag == "unlock_command"
+    assert sl.last_event_time is not None
+    assert (sl.last_event_time - before).total_seconds() <= 2
+    lock.async_write_ha_state.assert_called_once()
+    lock.coordinator.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_lock_async_unlock_api_error_leaves_optimistic_state_untouched() -> None:
+    """A failed command must not apply the optimistic update - no rollback is needed."""
+    sl = AjaxSmartLock(id="sl1", name="X", space_id="s1", is_locked=True)
+    sl.last_event_tag = "previous_tag"
+    sl.last_event_time = None
+    lock = _make_lock(sl)
+    lock.coordinator.api.async_send_device_command = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with pytest.raises(HomeAssistantError):
+        await lock.async_unlock()
+
+    assert sl.is_locked is True
+    assert sl.last_event_tag == "previous_tag"
+    assert sl.last_event_time is None
+    lock.async_write_ha_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lock_optimistic_state_survives_stale_poll() -> None:
+    """The existing 30s freshness guard in _apply_smart_lock_rest_state protects the optimistic value."""
+    sl = AjaxSmartLock(id="sl1", name="Front Door", space_id="s1")
+    lock = _make_lock(sl)
+
+    await lock.async_lock()
+    assert sl.is_locked is True
+
+    space = lock.coordinator.get_space(lock._space_id)
+    mixin = object.__new__(AjaxDevicesMixin)
+    mixin._apply_smart_lock_rest_state(space, "sl1", {"lockStatus": "UNLOCKED"})
+
+    assert sl.is_locked is True  # stale REST payload must not bounce the state back
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to the #88 field validation: the physical lock reacts immediately to `LOCK_SMART_LOCK`/`UNLOCK_SMART_LOCK`, but no realtime event arrives while disarmed, so the HA entity waited for the next poll cycle to reflect the change.

A successful command now applies an optimistic update: `is_locked` flips immediately (with `last_event_tag = lock_command`/`unlock_command`), and stamping `last_event_time` reuses the **existing** 30s freshness guard in `_apply_smart_lock_rest_state` so a stale REST payload cannot bounce the state back. A real SSE/SQS event, or the first poll after the window, remains the final authority. A failed command touches nothing (no rollback needed — the write only happens after a successful API call).

4 new tests, including an end-to-end anti-bounce test driving the real coordinator guard. 1975 tests green, `lock.py` at 100% coverage, mypy --strict 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lock and unlock commands now update the displayed lock status immediately after a successful action.
  * The latest action and timestamp are recorded without waiting for the next refresh.

* **Bug Fixes**
  * Prevented outdated status updates from overwriting a recently changed lock state.
  * Failed commands no longer incorrectly alter the displayed lock status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->