### PR TITLE
fix(video): classify NVR hardware variants (NVR_H_AC…) as NVR instead of UNKNOWN (#210)

### DIFF
--- a/custom_components/ajax/_coordinator_state.py
+++ b/custom_components/ajax/_coordinator_state.py
@@ -119,7 +119,13 @@ class AjaxStateUpdaterMixin:
                 try:
                     ve_type = VideoEdgeType(ve_type_str)
                 except ValueError:
-                    ve_type = VideoEdgeType.UNKNOWN
+                    # Ajax ships NVR hardware variants (e.g. NVR_H_AC, an 8-channel
+                    # AC/hardwired recorder) whose exact SKU code isn't in VideoEdgeType.
+                    # All downstream logic keys off `== VideoEdgeType.NVR`, so map any
+                    # NVR* code to NVR rather than UNKNOWN — otherwise a multi-channel
+                    # recorder is treated as a single generic camera (#210). Non-NVR
+                    # unknown types still fall through to UNKNOWN.
+                    ve_type = VideoEdgeType.NVR if ve_type_str.startswith("NVR") else VideoEdgeType.UNKNOWN
 
                 network = ve_data.get("networkInterface", {})
                 ethernet = network.get("ethernet", {})

--- a/tests/test_coordinator_state_coverage.py
+++ b/tests/test_coordinator_state_coverage.py
@@ -163,6 +163,46 @@ async def test_video_edges_add_new_with_full_payload() -> None:
 
 
 @pytest.mark.asyncio
+async def test_video_edges_nvr_variant_classified_as_nvr() -> None:
+    space = AjaxSpace(id="s1", name="Maison", real_space_id="real1")
+    mixin = _ve_mixin(space)
+    mixin.api.async_get_video_edges = AsyncMock(
+        return_value=[
+            {
+                "id": "ve_nvr",
+                "name": "NVR 8ch",
+                "type": "NVR_H_AC",  # 8-channel AC/hardwired variant -> ValueError branch
+                "connectionState": "ONLINE",
+                "networkInterface": {
+                    "ethernet": {
+                        "macAddress": "AA:CC",
+                        "configuration": {"v4": {"address": "192.168.1.20"}},
+                    },
+                    "wifi": {},
+                },
+                "channels": [
+                    {"spaceSettings": {"roomId": "r1"}},
+                    {"spaceSettings": {"roomId": "r1"}},
+                ],
+            }
+        ]
+    )
+    await mixin._async_update_video_edges("s1")
+    ve = space.video_edges["ve_nvr"]
+    assert ve.video_edge_type is VideoEdgeType.NVR
+
+
+@pytest.mark.asyncio
+async def test_video_edges_unknown_non_nvr_stays_unknown() -> None:
+    space = AjaxSpace(id="s1", name="Maison", real_space_id="real1")
+    mixin = _ve_mixin(space)
+    mixin.api.async_get_video_edges = AsyncMock(return_value=[{"id": "ve_unk", "type": "SOMETHING_ELSE"}])
+    await mixin._async_update_video_edges("s1")
+    ve = space.video_edges["ve_unk"]
+    assert ve.video_edge_type is VideoEdgeType.UNKNOWN
+
+
+@pytest.mark.asyncio
 async def test_video_edges_wifi_fallback_and_unknown_type_and_dict_channels() -> None:
     space = AjaxSpace(id="s1", name="Maison", real_space_id="real1")
     mixin = _ve_mixin(space)


### PR DESCRIPTION
Fixes #210.

An Ajax NVR reporting type `NVR_H_AC` (an 8-channel AC/hardwired variant) fell through to `VideoEdgeType.UNKNOWN` because the enum only defines `NVR` — so `VideoEdgeType("NVR_H_AC")` raises `ValueError`. The recorder was then treated as a single generic camera: no channel linkage, and ONVIF connected its cameras individually instead of via the NVR.

The `except ValueError` branch now maps any `NVR*` code to `VideoEdgeType.NVR` (non-NVR unknowns still fall through to `UNKNOWN`). All downstream logic already keys off `== VideoEdgeType.NVR`, so no other call site changes — and future NVR SKUs are covered without playing whack-a-mole on the enum. This is exactly the prefix-match the reporter suggested.

2 new tests (`NVR_H_AC` → NVR, `SOMETHING_ELSE` → UNKNOWN); the existing `NOT_A_REAL_TYPE` → UNKNOWN case stays green. 1977 tests pass, mypy --strict 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of NVR video devices, including NVR type variants.
  * Prevented unrecognized non-NVR device types from being incorrectly classified as NVR devices.

* **Tests**
  * Added coverage for NVR variants and unknown device types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->