### PR TITLE
fix(compat): support Home Assistant 2026.8 (aiobotocore/botocore pin + removed service helper)

### DIFF
--- a/custom_components/ajax/_services.py
+++ b/custom_components/ajax/_services.py
@@ -23,10 +23,10 @@ from homeassistant.exceptions import (
 from homeassistant.helpers import (
     config_validation as cv,
     entity_registry as er,
+    service as ha_service,
 )
 from homeassistant.helpers.service import (
     async_extract_config_entry_ids,
-    async_extract_referenced_entity_ids,
 )
 
 from ._raw_inventory import async_collect_raw_inventory
@@ -37,6 +37,28 @@ from .const import (
 from .coordinator import AjaxDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _extract_referenced_entity_ids(call: ServiceCall) -> set[str]:
+    """Return the entity ids a service call targets, across HA versions.
+
+    HA 2026.8 removed ``async_extract_referenced_entity_ids`` (and its
+    ``SelectedEntities`` breakdown) and exposes a synchronous
+    ``async_extract_entity_ids(service_call, expand_group) -> set[str]``.
+    Older HA (< 2026.8, down to the integration's 2025.11 floor) still ships
+    the referenced-entity helper, so use it there to preserve the exact prior
+    behaviour (direct + indirectly referenced) and fall back otherwise.
+    """
+    legacy = getattr(ha_service, "async_extract_referenced_entity_ids", None)
+    if legacy is not None:
+        selected = legacy(call.hass, call, expand_group=True)
+        return set(selected.referenced) | set(selected.indirectly_referenced)
+    # Accessed dynamically: the signature changed across HA versions (sync,
+    # ``hass`` dropped in 2026.8), so let this stay untyped rather than pin it
+    # to the stubs of whichever HA version mypy happens to run against.
+    extract_ids = getattr(ha_service, "async_extract_entity_ids")  # noqa: B009
+    return set(extract_ids(call, expand_group=True))
+
 
 # Service names
 SERVICE_FORCE_ARM = "force_arm"
@@ -73,8 +95,7 @@ async def _async_setup_services(hass: HomeAssistant) -> None:
         if coordinator.account is None:
             return []
         account = coordinator.account
-        selected = async_extract_referenced_entity_ids(call.hass, call, expand_group=True)
-        referenced = set(selected.referenced) | set(selected.indirectly_referenced)
+        referenced = _extract_referenced_entity_ids(call)
         if not referenced:
             return list(account.spaces.keys())
 

--- a/custom_components/ajax/manifest.json
+++ b/custom_components/ajax/manifest.json
@@ -21,7 +21,7 @@
   "loggers": ["custom_components.ajax"],
   "quality_scale": "platinum",
   "requirements": [
-    "aiobotocore>=3.8.0",
+    "aiobotocore>=3.7.0",
     "onvif-zeep-async>=4.2.1",
     "pyotp>=2.10.0"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,17 @@
       "enabled": false
     },
     {
+      "description": "Block minor/major aiobotocore bumps: HA core pins botocore==1.42.97 in its package_constraints, and aiobotocore>=3.8.0 requires botocore>=1.43.3, which is unresolvable at runtime (setup fails with 'Requirements not found') even though CI installs fine without HA's constraints. Keep on 3.7.x until HA raises its botocore pin. See the aiobotocore>=3.8.0 regression (#200).",
+      "matchPackageNames": [
+        "aiobotocore"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Auto-merge non-major updates once CI is green; major updates stay manual for review",
       "matchUpdateTypes": [
         "minor",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-mock
 
 # Integration runtime dep needed to import the package under test (kept in sync
 # with manifest.json).
-aiobotocore>=3.8.0
+aiobotocore>=3.7.0
 pyotp>=2.10.0

--- a/tests/test_init_coverage.py
+++ b/tests/test_init_coverage.py
@@ -181,14 +181,14 @@ async def test_force_arm_no_target_uses_all_spaces(tmp_path: Any) -> None:
     _, handlers = await _handlers(tmp_path)
     coord = _coord_with_spaces(["s1", "s2"])
     call = _call(_entry(coord))
-    selected = SimpleNamespace(referenced=set(), indirectly_referenced=set())
+    selected: set[str] = set()
     with (
         patch(
             "custom_components.ajax._services.async_extract_config_entry_ids",
             AsyncMock(return_value=set()),
         ),
         patch(
-            "custom_components.ajax._services.async_extract_referenced_entity_ids",
+            "custom_components.ajax._services._extract_referenced_entity_ids",
             return_value=selected,
         ),
     ):
@@ -202,10 +202,7 @@ async def test_force_arm_resolves_referenced_entity_to_space(tmp_path: Any) -> N
     _, handlers = await _handlers(tmp_path)
     coord = _coord_with_spaces(["space42"])
     call = _call(_entry(coord))
-    selected = SimpleNamespace(
-        referenced={"alarm_control_panel.ajax"},
-        indirectly_referenced=set(),
-    )
+    selected = {"alarm_control_panel.ajax"}
     registry = MagicMock()
     reg_entry = SimpleNamespace(
         domain="alarm_control_panel",
@@ -218,7 +215,7 @@ async def test_force_arm_resolves_referenced_entity_to_space(tmp_path: Any) -> N
             AsyncMock(return_value=set()),
         ),
         patch(
-            "custom_components.ajax._services.async_extract_referenced_entity_ids",
+            "custom_components.ajax._services._extract_referenced_entity_ids",
             return_value=selected,
         ),
         patch("custom_components.ajax._services.er.async_get", return_value=registry),
@@ -232,10 +229,7 @@ async def test_force_arm_ignores_non_alarm_and_unknown_entities(tmp_path: Any) -
     _, handlers = await _handlers(tmp_path)
     coord = _coord_with_spaces(["known"])
     call = _call(_entry(coord))
-    selected = SimpleNamespace(
-        referenced={"sensor.foo", "alarm_control_panel.missing", "alarm_control_panel.unknown"},
-        indirectly_referenced=set(),
-    )
+    selected = {"sensor.foo", "alarm_control_panel.missing", "alarm_control_panel.unknown"}
     registry = MagicMock()
 
     def _get(entity_id: str) -> Any:
@@ -253,7 +247,7 @@ async def test_force_arm_ignores_non_alarm_and_unknown_entities(tmp_path: Any) -
             AsyncMock(return_value=set()),
         ),
         patch(
-            "custom_components.ajax._services.async_extract_referenced_entity_ids",
+            "custom_components.ajax._services._extract_referenced_entity_ids",
             return_value=selected,
         ),
         patch("custom_components.ajax._services.er.async_get", return_value=registry),
@@ -286,14 +280,14 @@ async def test_force_arm_collects_failures(tmp_path: Any) -> None:
     coord = _coord_with_spaces(["s1"])
     coord.async_arm_space.side_effect = RuntimeError("boom")
     call = _call(_entry(coord))
-    selected = SimpleNamespace(referenced=set(), indirectly_referenced=set())
+    selected: set[str] = set()
     with (
         patch(
             "custom_components.ajax._services.async_extract_config_entry_ids",
             AsyncMock(return_value=set()),
         ),
         patch(
-            "custom_components.ajax._services.async_extract_referenced_entity_ids",
+            "custom_components.ajax._services._extract_referenced_entity_ids",
             return_value=selected,
         ),
         pytest.raises(HomeAssistantError),
@@ -317,19 +311,47 @@ async def test_resolve_target_spaces_empty_when_account_none(tmp_path: Any) -> N
         await handlers[SERVICE_FORCE_ARM](call)
 
 
+def test_extract_referenced_entity_ids_legacy_branch(monkeypatch: Any) -> None:
+    """< HA 2026.8: uses async_extract_referenced_entity_ids and merges the breakdown."""
+    from custom_components.ajax import _services
+
+    sel = SimpleNamespace(referenced={"a"}, indirectly_referenced={"b"})
+    monkeypatch.setattr(
+        _services.ha_service,
+        "async_extract_referenced_entity_ids",
+        lambda hass, call, expand_group=True: sel,
+        raising=False,
+    )
+    assert _services._extract_referenced_entity_ids(MagicMock()) == {"a", "b"}
+
+
+def test_extract_referenced_entity_ids_fallback_branch(monkeypatch: Any) -> None:
+    """HA 2026.8+ removed the referenced helper: fall back to sync async_extract_entity_ids."""
+    from custom_components.ajax import _services
+
+    monkeypatch.delattr(_services.ha_service, "async_extract_referenced_entity_ids", raising=False)
+    monkeypatch.setattr(
+        _services.ha_service,
+        "async_extract_entity_ids",
+        lambda call, expand_group=True: {"x", "y"},
+        raising=False,
+    )
+    assert _services._extract_referenced_entity_ids(MagicMock()) == {"x", "y"}
+
+
 async def test_force_arm_night_success(tmp_path: Any) -> None:
     """force_arm_night arms each resolved space in night mode with force=True."""
     _, handlers = await _handlers(tmp_path)
     coord = _coord_with_spaces(["s1", "s2"])
     call = _call(_entry(coord))
-    selected = SimpleNamespace(referenced=set(), indirectly_referenced=set())
+    selected: set[str] = set()
     with (
         patch(
             "custom_components.ajax._services.async_extract_config_entry_ids",
             AsyncMock(return_value=set()),
         ),
         patch(
-            "custom_components.ajax._services.async_extract_referenced_entity_ids",
+            "custom_components.ajax._services._extract_referenced_entity_ids",
             return_value=selected,
         ),
     ):
@@ -359,10 +381,7 @@ async def test_force_arm_night_unresolved_target_raises(tmp_path: Any) -> None:
     _, handlers = await _handlers(tmp_path)
     coord = _coord_with_spaces(["known"])
     call = _call(_entry(coord))
-    selected = SimpleNamespace(
-        referenced={"alarm_control_panel.ghost"},
-        indirectly_referenced=set(),
-    )
+    selected = {"alarm_control_panel.ghost"}
     registry = MagicMock()
     registry.async_get.return_value = SimpleNamespace(
         domain="alarm_control_panel",
@@ -374,7 +393,7 @@ async def test_force_arm_night_unresolved_target_raises(tmp_path: Any) -> None:
             AsyncMock(return_value=set()),
         ),
         patch(
-            "custom_components.ajax._services.async_extract_referenced_entity_ids",
+            "custom_components.ajax._services._extract_referenced_entity_ids",
             return_value=selected,
         ),
         patch("custom_components.ajax._services.er.async_get", return_value=registry),
@@ -390,14 +409,14 @@ async def test_force_arm_night_collects_failures(tmp_path: Any) -> None:
     coord = _coord_with_spaces(["s1"])
     coord.async_arm_night_mode.side_effect = RuntimeError("nope")
     call = _call(_entry(coord))
-    selected = SimpleNamespace(referenced=set(), indirectly_referenced=set())
+    selected: set[str] = set()
     with (
         patch(
             "custom_components.ajax._services.async_extract_config_entry_ids",
             AsyncMock(return_value=set()),
         ),
         patch(
-            "custom_components.ajax._services.async_extract_referenced_entity_ids",
+            "custom_components.ajax._services._extract_referenced_entity_ids",
             return_value=selected,
         ),
         pytest.raises(HomeAssistantError),
@@ -1126,10 +1145,7 @@ async def test_force_arm_skips_group_panels(tmp_path: Any) -> None:
     _, handlers = await _handlers(tmp_path)
     coord = _coord_with_spaces(["g42"])
     call = _call(_entry(coord))
-    selected = SimpleNamespace(
-        referenced={"alarm_control_panel.perimeter_group"},
-        indirectly_referenced=set(),
-    )
+    selected = {"alarm_control_panel.perimeter_group"}
     registry = MagicMock()
     registry.async_get.return_value = SimpleNamespace(
         domain="alarm_control_panel",
@@ -1141,7 +1157,7 @@ async def test_force_arm_skips_group_panels(tmp_path: Any) -> None:
             AsyncMock(return_value=set()),
         ),
         patch(
-            "custom_components.ajax._services.async_extract_referenced_entity_ids",
+            "custom_components.ajax._services._extract_referenced_entity_ids",
             return_value=selected,
         ),
         patch("custom_components.ajax._services.er.async_get", return_value=registry),


### PR DESCRIPTION
Two HA 2026.8 breaking changes stop the integration from loading. A user on the 2026.8.0b1 beta hit both; they'll hit every user once 2026.8 goes stable.

### 1. `aiobotocore>=3.8.0` is uninstallable on HA 2026.8
HA core now pins `botocore==1.42.97` in its package constraints; `aiobotocore>=3.8.0` needs `botocore>=1.43.3`, so the runtime requirement install fails with `Requirements for ajax not found: ['aiobotocore>=3.8.0']` and the whole integration fails to set up. (HA 2026.7.x has no such pin, so current stable is unaffected — this is forward-compat.)

- Revert the floor to `aiobotocore>=3.7.0` (resolves to 3.7.0 under HA's botocore pin, works on every supported HA version).
- Add a Renovate rule blocking minor/major aiobotocore bumps, mirroring the grpcio/protobuf guard. The `>=3.8.0` floor came from Renovate #200; CI didn't catch it because it installs `requirements_test.txt` without HA core's package constraints.

### 2. `async_extract_referenced_entity_ids` removed in HA 2026.8
`homeassistant.helpers.service.async_extract_referenced_entity_ids` (and its `SelectedEntities` breakdown) is gone; `async_extract_entity_ids` is now a sync `(service_call, expand_group) -> set[str]` helper. The top-level import crashed the component (`Unable to import component`).

- `_services.py` now resolves force-arm targets through a version shim: legacy helper on `< 2026.8`, `async_extract_entity_ids` fallback otherwise. Tests migrated to the new seam + 2 shim tests covering both branches.

**Verified on a live HA 2026.8.0b1 dev instance**: setup completes in ~1.8s, `AWS SQS initialized`, coordinator `success: True`, zero errors/tracebacks. 1979 tests, mypy --strict 0, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with multiple Home Assistant versions.
  * Preserved force-arm and force-arm-night target resolution, including referenced entities and groups.
  * Maintained existing arming and validation behavior across supported versions.

* **Chores**
  * Relaxed the supported `aiobotocore` version requirement.
  * Prevented unsupported major and minor `aiobotocore` updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->