### PR TITLE
fix(compat): migrate ppm unit off CONCENTRATION_PARTS_PER_MILLION (HA 2026.8 deprecation)

### DIFF
--- a/custom_components/ajax/devices/life_quality.py
+++ b/custom_components/ajax/devices/life_quality.py
@@ -14,12 +14,25 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
     UnitOfTemperature,
 )
 
 from .base import AjaxDeviceHandler
+
+# CONCENTRATION_PARTS_PER_MILLION is deprecated since HA 2026.8 (removal in
+# 2027.8) in favour of UnitOfRatio, which only exists since HA 2026.7 — fall
+# back for the supported 2025.11–2026.6 range. Both spell the identical "ppm"
+# unit string, so recorded statistics are unaffected.
+_PARTS_PER_MILLION: str
+try:
+    from homeassistant.const import UnitOfRatio
+
+    _PARTS_PER_MILLION = UnitOfRatio.PARTS_PER_MILLION
+except ImportError:  # pragma: no cover - HA < 2026.7
+    from homeassistant.const import (
+        CONCENTRATION_PARTS_PER_MILLION as _PARTS_PER_MILLION,
+    )
 
 
 class LifeQualityHandler(AjaxDeviceHandler):
@@ -83,7 +96,7 @@ class LifeQualityHandler(AjaxDeviceHandler):
             {
                 "key": "co2",
                 "device_class": SensorDeviceClass.CO2,
-                "native_unit_of_measurement": CONCENTRATION_PARTS_PER_MILLION,
+                "native_unit_of_measurement": _PARTS_PER_MILLION,
                 "state_class": SensorStateClass.MEASUREMENT,
                 "value_fn": lambda: self.device.attributes.get("actualCO2"),
                 "enabled_by_default": True,

--- a/custom_components/ajax/devices/smoke_detector.py
+++ b/custom_components/ajax/devices/smoke_detector.py
@@ -18,11 +18,22 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
 )
-from homeassistant.const import (
-    CONCENTRATION_PARTS_PER_MILLION,
-)
 
 from .base import AjaxDeviceHandler
+
+# CONCENTRATION_PARTS_PER_MILLION is deprecated since HA 2026.8 (removal in
+# 2027.8) in favour of UnitOfRatio, which only exists since HA 2026.7 — fall
+# back for the supported 2025.11–2026.6 range. Both spell the identical "ppm"
+# unit string, so recorded statistics are unaffected.
+_PARTS_PER_MILLION: str
+try:
+    from homeassistant.const import UnitOfRatio
+
+    _PARTS_PER_MILLION = UnitOfRatio.PARTS_PER_MILLION
+except ImportError:  # pragma: no cover - HA < 2026.7
+    from homeassistant.const import (
+        CONCENTRATION_PARTS_PER_MILLION as _PARTS_PER_MILLION,
+    )
 
 
 class SmokeDetectorHandler(AjaxDeviceHandler):
@@ -137,7 +148,7 @@ class SmokeDetectorHandler(AjaxDeviceHandler):
                 {
                     "key": "co_level",
                     "device_class": SensorDeviceClass.CO,
-                    "native_unit_of_measurement": CONCENTRATION_PARTS_PER_MILLION,
+                    "native_unit_of_measurement": _PARTS_PER_MILLION,
                     "state_class": SensorStateClass.MEASUREMENT,
                     "value_fn": lambda: self.device.attributes.get("co_level"),
                     "enabled_by_default": True,


### PR DESCRIPTION
HA 2026.8 deprecates `CONCENTRATION_PARTS_PER_MILLION` (removal scheduled for 2027.8) in favour of `UnitOfRatio.PARTS_PER_MILLION`, which only exists since HA 2026.7.

The LifeQuality CO2 sensor and the FireProtect CO-level sensor now use `UnitOfRatio.PARTS_PER_MILLION` with an `ImportError` fallback to the old constant for the supported 2025.11–2026.6 range. Both resolve to the identical `"ppm"` unit string, so recorded statistics carry over unchanged (verified on HA 2026.8.0b1: `str(UnitOfRatio.PARTS_PER_MILLION) == "ppm"`).

Verified on a live HA 2026.8.0b1 instance: setup succeeds, no ppm deprecation warning. 1979 tests, mypy --strict 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for CO₂ and carbon monoxide sensor units across newer and older Home Assistant versions.
  - Prevented potential sensor unit errors caused by deprecated measurement constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->