### PR TITLE
perf(api): cache hub list to avoid duplicate fetch at boot

### DIFF
--- a/custom_components/ajax/api/_base.py
+++ b/custom_components/ajax/api/_base.py
@@ -174,6 +174,15 @@ class AjaxRestClientBase:
         self._devices_cache: dict[tuple[str, bool], tuple[float, list[dict[str, Any]]]] = {}
         self._devices_cache_ttl: float = 5.0
 
+        # Short-lived cache of the GET /user/{id}/hubs list. At setup the
+        # connection test and the coordinator's first refresh both fetch it
+        # back-to-back; without coalescing the first boot pays for the round
+        # trip twice. A short TTL also folds in any rapid consecutive ticks
+        # (e.g. an SSE/SQS-triggered refresh landing right after the periodic
+        # one) with no staleness risk — hub membership changes slowly.
+        self._hubs_cache: tuple[float, list[dict[str, Any]]] | None = None
+        self._hubs_cache_ttl: float = 5.0
+
         # Base headers with API key (may be empty for proxy modes initially)
         self._base_headers = {
             "Content-Type": "application/json",

--- a/custom_components/ajax/api/_hubs.py
+++ b/custom_components/ajax/api/_hubs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from ._base import (
@@ -16,12 +17,24 @@ class _HubsMixin(AjaxRestClientBase):
     async def async_get_hubs(self) -> list[dict[str, Any]]:
         """Get all hubs.
 
+        Coalesced by a short-lived in-memory cache (``_hubs_cache``): the
+        setup connection test and the coordinator's first refresh fetch the
+        hub list back-to-back, so without it every boot pays the round trip
+        twice. The entry is served only inside its TTL and never across an
+        open cache-bypass window (see ``_cache_entry_usable``), so a post-SSE
+        refresh always reaches the real endpoint.
+
         Returns:
             List of hub dictionaries
         """
+        cached = self._hubs_cache
+        if cached and self._cache_entry_usable(cached[0], self._hubs_cache_ttl):
+            return cached[1]
         if not self.user_id:
             raise AjaxRestApiError("No user_id available. Call async_login() first.")
-        return await self._request("GET", f"user/{self.user_id}/hubs")  # type: ignore[no-any-return]
+        data = await self._request("GET", f"user/{self.user_id}/hubs")
+        self._hubs_cache = (time.time(), data)
+        return data  # type: ignore[no-any-return]
 
     async def async_get_hub(self, hub_id: str) -> dict[str, Any]:
         """Get hub details.

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -56,6 +56,49 @@ async def test_async_get_hub_routes_via_user() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_get_hubs_caches_response_for_ttl_window() -> None:
+    """Boot: the connection test and the first refresh both fetch hubs.
+
+    Two calls within the TTL window must hit the network only once — this is
+    the exact pattern `async_setup_entry` + the coordinator's first refresh
+    produce at every boot.
+    """
+    api = _api()
+    api._request.return_value = [{"hubId": "h1"}]
+
+    first = await api.async_get_hubs()
+    second = await api.async_get_hubs()
+
+    assert first == second == [{"hubId": "h1"}]
+    api._request.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_get_hubs_cache_expires_after_ttl() -> None:
+    """Past the TTL window, a fresh request must fire."""
+    api = _api()
+    api._hubs_cache_ttl = 0.01
+    api._request.return_value = [{"hubId": "h1"}]
+
+    await api.async_get_hubs()
+    # Forge an expired cache entry (rather than sleeping).
+    api._hubs_cache = (time.time() - 10.0, [{"hubId": "stale"}])
+    await api.async_get_hubs()
+    assert api._request.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_get_hubs_cache_bypassed_when_bypass_flag_set() -> None:
+    """bypass_cache_next() must let the next call escape the hubs cache."""
+    api = _api()
+    api._request.return_value = [{"hubId": "h1"}]
+    await api.async_get_hubs()
+    api.bypass_cache_next()
+    await api.async_get_hubs()
+    assert api._request.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_async_set_hub_mode_sends_post_with_mode_payload() -> None:
     api = _api()
     await api.async_set_hub_mode("h1", "full")


### PR DESCRIPTION
## Summary

`async_setup_entry` calls `api.async_get_hubs()` as a connection test, then the coordinator's first refresh (`_async_update_spaces_from_hubs`) fetches the **same hub list again**. That duplicate round-trip adds ~600-700ms of boot latency on every start.

This PR adds a short-lived TTL cache to `async_get_hubs()`, following the existing `_devices_cache` / `_space_cache` pattern. The connection test populates the cache; the first refresh is served from it (TTL 5s, and never across an open cache-bypass window so post-SSE refreshes still reach the real endpoint).

## Changes
- `api/_base.py`: `_hubs_cache` + TTL state
- `api/_hubs.py`: `async_get_hubs()` serves from cache within TTL
- `tests/test_api_endpoints.py`: 3 new tests (TTL window coalescing, expiry, bypass)

## Testing
- Full suite: 1991 passed
- Coverage: 99% total, `_hubs.py` 100%
- ruff + mypy clean
- Boot verified on HA dev: no second hubs fetch during first refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Hub lists now load more quickly by reusing recently retrieved data for up to five seconds.
  * Hub information automatically refreshes after the cache expires or when a refresh is requested.

* **Bug Fixes**
  * Improved handling of hub-list refresh behavior to ensure updated information is retrieved when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->