### PR TITLE
fix(devices): link parent devices by id so camera entities register

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,8 @@ home-assistant_v2.db
 CLAUDE.md
 AGENTS.md
 ajax-hass-dev.md
+
+# Reverse-engineering app officielle Ajax (binaire + décompilation brute)
+*.apks
+*.apk
+/.reverse/

--- a/custom_components/ajax/__init__.py
+++ b/custom_components/ajax/__init__.py
@@ -18,7 +18,8 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from ._ids import device_identifier
+from ._device_parents import async_register_parent_devices
+from ._ids import find_device
 from ._services import (  # noqa: F401  (SERVICE_* re-exported for tests/back-compat)
     SERVICE_FORCE_ARM,
     SERVICE_FORCE_ARM_NIGHT,
@@ -217,6 +218,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxConfigEntry) -> bool
     # Fetch initial data
     await coordinator.async_config_entry_first_refresh()
 
+    # Register the devices other devices hang off (hubs, then NVRs) before the
+    # platforms run: entities express their parent link as a device-registry id,
+    # which can only be resolved once the parent exists.
+    async_register_parent_devices(hass, entry, coordinator)
+
     # Set up platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -342,9 +348,7 @@ async def _async_setup_areas(hass: HomeAssistant, coordinator: AjaxDataCoordinat
             for device_id, device in space.devices.items():
                 if device.room_id == room_id:
                     # Find the HA device by identifiers
-                    ha_device = device_reg.async_get_device(
-                        identifiers={device_identifier(coordinator.entry_id, device_id)}
-                    )
+                    ha_device = find_device(device_reg, coordinator.entry_id, device_id)
                     # Only assign area if device has no area yet (respect user changes)
                     if ha_device and ha_device.area_id is None:
                         device_reg.async_update_device(ha_device.id, area_id=area.id)

--- a/custom_components/ajax/_binary_sensor_entities.py
+++ b/custom_components/ajax/_binary_sensor_entities.py
@@ -23,7 +23,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from ._ids import device_identifier
+from ._ids import device_identifier, find_device, via_device_info
 from .const import MANUFACTURER
 from .coordinator import AjaxDataCoordinator
 from .devices.base import resolve_entity_category
@@ -135,9 +135,7 @@ class AjaxBinarySensor(CoordinatorEntity[AjaxDataCoordinator], BinarySensorEntit
             return
 
         device_registry = dr.async_get(self.hass)
-        device_entry = device_registry.async_get_device(
-            identifiers={device_identifier(self.coordinator.entry_id, self._device_id)}
-        )
+        device_entry = find_device(device_registry, self.coordinator.entry_id, self._device_id)
         if not device_entry:
             return
 
@@ -174,7 +172,7 @@ class AjaxBinarySensor(CoordinatorEntity[AjaxDataCoordinator], BinarySensorEntit
             name=device.name,
             manufacturer=MANUFACTURER,
             model=model_name,
-            via_device=device_identifier(self.coordinator.entry_id, self._space_id),
+            **via_device_info(self.coordinator.hass, self.coordinator.entry_id, self._space_id),
             sw_version=device.firmware_version,
             hw_version=device.hardware_version,
             suggested_area=device.room_name,
@@ -270,19 +268,19 @@ class AjaxVideoEdgeBinarySensor(CoordinatorEntity[AjaxDataCoordinator], BinarySe
         if video_edge.color:
             model_name = f"{model_name} ({video_edge.color.title()})"
 
-        # Determine via_device: if camera is recorded by NVR, link to NVR
+        # Determine the parent device: if the camera is recorded by an NVR, link to the NVR
         # Otherwise link to hub (space_id)
-        via_device_id = self._space_id
+        parent_id = self._space_id
         nvr_id = self._get_recording_nvr_id()
         if nvr_id:
-            via_device_id = nvr_id
+            parent_id = nvr_id
 
         return DeviceInfo(
             identifiers={device_identifier(self.coordinator.entry_id, self._video_edge_id)},
             name=video_edge.name,
             manufacturer=MANUFACTURER,
             model=model_name,
-            via_device=device_identifier(self.coordinator.entry_id, via_device_id),
+            **via_device_info(self.coordinator.hass, self.coordinator.entry_id, parent_id),
             sw_version=video_edge.firmware_version,
             suggested_area=video_edge.room_name,
         )
@@ -438,7 +436,7 @@ class AjaxSmartLockBinarySensor(CoordinatorEntity[AjaxDataCoordinator], BinarySe
             name=smart_lock.name,
             manufacturer=MANUFACTURER,
             model="LockBridge Jeweller",
-            via_device=device_identifier(self.coordinator.entry_id, self._space_id),
+            **via_device_info(self.coordinator.hass, self.coordinator.entry_id, self._space_id),
         )
 
     def _get_smart_lock(self) -> AjaxSmartLock | None:

--- a/custom_components/ajax/_coordinator_devices.py
+++ b/custom_components/ajax/_coordinator_devices.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from ._device_apply import apply_device_payload
 from ._device_normalize import AjaxDeviceNormalizeMixin
-from ._ids import device_identifier
+from ._ids import find_device
 from .const import DOMAIN, SIGNAL_NEW_DEVICE
 from .models import AjaxDevice, DeviceType
 
@@ -304,9 +304,7 @@ class AjaxDevicesMixin(AjaxDeviceNormalizeMixin):
                     device_name = removed_device.name if removed_device else device_id
 
                     # Remove from HA device registry
-                    ha_device = device_registry.async_get_device(
-                        identifiers={device_identifier(self.entry_id, device_id)}
-                    )
+                    ha_device = find_device(device_registry, self.entry_id, device_id)
                     if ha_device:
                         device_registry.async_remove_device(ha_device.id)
                         _LOGGER.info(

--- a/custom_components/ajax/_coordinator_state.py
+++ b/custom_components/ajax/_coordinator_state.py
@@ -23,7 +23,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from ._device_type_map import DEVICE_TYPE_MAP
-from ._ids import device_identifier
+from ._ids import find_device
 from .api import AjaxRestAuthError
 from .const import SIGNAL_NEW_SMART_LOCK, SIGNAL_NEW_VIDEO_EDGE
 from .models import (
@@ -218,9 +218,7 @@ class AjaxStateUpdaterMixin:
                         removed_ve = space.video_edges.get(ve_id)
                         ve_name = removed_ve.name if removed_ve else ve_id
 
-                        ha_device = device_registry.async_get_device(
-                            identifiers={device_identifier(self.entry_id, ve_id)}
-                        )
+                        ha_device = find_device(device_registry, self.entry_id, ve_id)
                         if ha_device:
                             device_registry.async_remove_device(ha_device.id)
                             _LOGGER.info(
@@ -334,9 +332,7 @@ class AjaxStateUpdaterMixin:
 
                         sl_name = removed_sl.name if removed_sl else sl_id
 
-                        ha_device = device_registry.async_get_device(
-                            identifiers={device_identifier(self.entry_id, sl_id)}
-                        )
+                        ha_device = find_device(device_registry, self.entry_id, sl_id)
                         if ha_device:
                             device_registry.async_remove_device(ha_device.id)
                             _LOGGER.info(

--- a/custom_components/ajax/_device_parents.py
+++ b/custom_components/ajax/_device_parents.py
@@ -1,0 +1,69 @@
+"""Pre-registration of the devices other Ajax devices hang off.
+
+Entities express their parent link with ``via_device_id``, a device-registry
+id — which only resolves once the parent device is registered. Platform setup
+order does not guarantee that: the ``camera`` platform runs before ``sensor``,
+yet an NVR channel camera's parent (the NVR itself) is first described by a
+sensor entity. Registering hubs and NVRs up front removes the ordering
+constraint; the entities that own those devices then simply enrich them.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
+
+from ._ids import device_identifier
+from .const import MANUFACTURER, AjaxConfigEntry
+from .coordinator import AjaxDataCoordinator
+from .models import VIDEO_EDGE_MODEL_NAMES, VideoEdgeType
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@callback
+def async_register_parent_devices(
+    hass: HomeAssistant,
+    entry: AjaxConfigEntry,
+    coordinator: AjaxDataCoordinator,
+) -> None:
+    """Register every hub and NVR of the account in the device registry.
+
+    Hubs first, then NVRs (whose own parent is a hub). Safe to call again:
+    ``async_get_or_create`` updates the existing device instead of duplicating
+    it, so the discovery path can reuse this for objects appearing later.
+    """
+    if coordinator.data is None:
+        return
+
+    device_reg = dr.async_get(hass)
+    entry_id = coordinator.entry_id
+
+    for space in coordinator.data.spaces.values():
+        device_reg.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={device_identifier(entry_id, space.id)},
+            name=space.name,
+            manufacturer=MANUFACTURER,
+        )
+
+    for space in coordinator.data.spaces.values():
+        for video_edge in space.video_edges.values():
+            if video_edge.video_edge_type != VideoEdgeType.NVR:
+                continue
+            model_name = VIDEO_EDGE_MODEL_NAMES.get(video_edge.video_edge_type, video_edge.video_edge_type.value)
+            # The NVR's own link back to its hub is left to the entities that
+            # own the device: by the time they build their DeviceInfo the hub
+            # is registered, so the link resolves there without duplicating
+            # the version-compat handling of via_device_info here.
+            device_reg.async_get_or_create(
+                config_entry_id=entry.entry_id,
+                identifiers={device_identifier(entry_id, video_edge.id)},
+                name=video_edge.name,
+                manufacturer=MANUFACTURER,
+                model=model_name,
+                sw_version=video_edge.firmware_version,
+            )
+            _LOGGER.debug("Pre-registered NVR device %s", video_edge.name)

--- a/custom_components/ajax/_discovery.py
+++ b/custom_components/ajax/_discovery.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from ._device_parents import async_register_parent_devices
 from .const import DOMAIN
 
 if TYPE_CHECKING:
@@ -81,6 +82,10 @@ def connect_new_entity_signal(
             and ent_reg.async_get_entity_id(platform_domain, DOMAIN, entity.unique_id) is None
         ]
         if fresh:
+            # A freshly-discovered object may be (or hang off) a parent device
+            # that is not in the registry yet; register parents first so the
+            # entities' via_device_id link resolves.
+            async_register_parent_devices(hass, entry, entry.runtime_data)
             async_add_entities(fresh)
             _LOGGER.info("Dynamically added %d %s", len(fresh), label)
 

--- a/custom_components/ajax/_ids.py
+++ b/custom_components/ajax/_ids.py
@@ -17,7 +17,22 @@ identical.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
+
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceInfo
+
 from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+# ``DeviceInfo.via_device`` (an identifier tuple) is deprecated since HA 2026.8
+# in favour of ``via_device_id`` (a device-registry id). On a Home Assistant
+# recent enough to raise on the deprecated form, the new key is used; older
+# supported cores (>= 2025.11) do not know ``via_device_id`` at all, so the
+# tuple form is kept there.
+_SUPPORTS_VIA_DEVICE_ID = hasattr(dr.DeviceRegistry, "async_get_device_by_identifier")
 
 
 def device_identifier(entry_id: str, raw_id: str) -> tuple[str, str]:
@@ -26,3 +41,39 @@ def device_identifier(entry_id: str, raw_id: str) -> tuple[str, str]:
     ``raw_id`` is the bare Ajax id (hub/space/device/video-edge/smart-lock).
     """
     return (DOMAIN, f"{entry_id}_{raw_id}")
+
+
+def find_device(device_registry: dr.DeviceRegistry, entry_id: str, raw_id: str) -> dr.DeviceEntry | None:
+    """Return the registry entry for an Ajax object, or ``None``.
+
+    ``DeviceRegistry.async_get_device`` is deprecated since HA 2026.8 because a
+    bare identifier is not unique across config entries; the entry-scoped
+    lookup replaces it where available. Ajax identifiers are already namespaced
+    with the entry id (see ``device_identifier``), so both forms resolve to the
+    same device — only the deprecation warning differs.
+    """
+    identifier = device_identifier(entry_id, raw_id)
+    if _SUPPORTS_VIA_DEVICE_ID:
+        return device_registry.async_get_device_by_identifier(identifier, entry_id)
+    return device_registry.async_get_device(identifiers={identifier})
+
+
+def via_device_info(hass: HomeAssistant, entry_id: str, raw_id: str) -> DeviceInfo:
+    """Return the parent-device part of a ``DeviceInfo``, to merge into one.
+
+    On a core that supports it the link is expressed as ``via_device_id`` (a
+    device-registry id); the parents (hubs and NVRs) are pre-registered in
+    ``async_setup_entry`` before the platforms are forwarded, which is what
+    makes the lookup succeed regardless of platform setup order.
+
+    Returns an empty mapping when the parent is not registered: an unknown
+    ``via_device_id`` is rejected by the device registry, so the key must be
+    omitted entirely rather than set to ``None``.
+    """
+    if not _SUPPORTS_VIA_DEVICE_ID:
+        return cast(DeviceInfo, {"via_device": device_identifier(entry_id, raw_id)})
+
+    device = find_device(dr.async_get(hass), entry_id, raw_id)
+    if device is None:
+        return DeviceInfo()
+    return cast(DeviceInfo, {"via_device_id": device.id})

--- a/custom_components/ajax/_sensor_device.py
+++ b/custom_components/ajax/_sensor_device.py
@@ -16,7 +16,7 @@ from homeassistant.components.sensor import (
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from ._ids import device_identifier
+from ._ids import device_identifier, via_device_info
 from .const import MANUFACTURER
 from .coordinator import AjaxDataCoordinator
 from .devices.base import resolve_entity_category
@@ -121,7 +121,7 @@ class AjaxDeviceSensor(CoordinatorEntity[AjaxDataCoordinator], SensorEntity):
             name=device.name,
             manufacturer=MANUFACTURER,
             model=device.raw_type,
-            via_device=device_identifier(self.coordinator.entry_id, self._space_id),
+            **via_device_info(self.coordinator.hass, self.coordinator.entry_id, self._space_id),
             sw_version=device.firmware_version,
             hw_version=device.hardware_version,
             suggested_area=device.room_name,
@@ -242,19 +242,19 @@ class AjaxVideoEdgeSensor(CoordinatorEntity[AjaxDataCoordinator], SensorEntity):
         if video_edge.color:
             model_name = f"{model_name} ({video_edge.color.title()})"
 
-        # Determine via_device: if camera is recorded by NVR, link to NVR
+        # Determine the parent device: if the camera is recorded by an NVR, link to the NVR
         # Otherwise link to hub (space_id)
-        via_device_id = self._space_id
+        parent_id = self._space_id
         nvr_id = self._get_recording_nvr_id()
         if nvr_id:
-            via_device_id = nvr_id
+            parent_id = nvr_id
 
         return DeviceInfo(
             identifiers={device_identifier(self.coordinator.entry_id, self._video_edge_id)},
             name=video_edge.name,
             manufacturer=MANUFACTURER,
             model=model_name,
-            via_device=device_identifier(self.coordinator.entry_id, via_device_id),
+            **via_device_info(self.coordinator.hass, self.coordinator.entry_id, parent_id),
             sw_version=video_edge.firmware_version,
             suggested_area=video_edge.room_name,
         )

--- a/custom_components/ajax/_sensor_smart_lock.py
+++ b/custom_components/ajax/_sensor_smart_lock.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import (
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from ._ids import device_identifier
+from ._ids import device_identifier, via_device_info
 from .const import MANUFACTURER
 from .coordinator import AjaxDataCoordinator
 from .models import (
@@ -69,7 +69,7 @@ class AjaxSmartLockSensor(CoordinatorEntity[AjaxDataCoordinator], SensorEntity):
             name=smart_lock.name,
             manufacturer=MANUFACTURER,
             model="LockBridge Jeweller",
-            via_device=device_identifier(self.coordinator.entry_id, self._space_id),
+            **via_device_info(self.coordinator.hass, self.coordinator.entry_id, self._space_id),
         )
 
     def _get_smart_lock(self) -> AjaxSmartLock | None:

--- a/custom_components/ajax/_switch_entity.py
+++ b/custom_components/ajax/_switch_entity.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from ._ids import device_identifier
+from ._ids import device_identifier, via_device_info
 from .const import DOMAIN, MANUFACTURER
 from .coordinator import AjaxDataCoordinator
 from .models import AjaxDevice, AjaxSpace, DeviceType, SecurityState
@@ -476,7 +476,7 @@ class AjaxSwitch(CoordinatorEntity[AjaxDataCoordinator], SwitchEntity):
             name=device.name,
             manufacturer=MANUFACTURER,
             model=device.raw_type,
-            via_device=device_identifier(self.coordinator.entry_id, self._space_id),
+            **via_device_info(self.coordinator.hass, self.coordinator.entry_id, self._space_id),
             sw_version=device.firmware_version,
             hw_version=device.hardware_version,
             suggested_area=device.room_name,

--- a/custom_components/ajax/alarm_control_panel.py
+++ b/custom_components/ajax/alarm_control_panel.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import AjaxConfigEntry
 from ._discovery import connect_new_entity_signal
-from ._ids import device_identifier
+from ._ids import device_identifier, find_device
 from .const import DOMAIN, MANUFACTURER, SIGNAL_NEW_GROUP, SIGNAL_NEW_SPACE
 from .coordinator import AjaxDataCoordinator
 from .models import GroupState, SecurityState
@@ -282,9 +282,7 @@ class AjaxAlarmControlPanel(CoordinatorEntity[AjaxDataCoordinator], AlarmControl
             return
 
         device_registry = dr.async_get(self.hass)
-        device_entry = device_registry.async_get_device(
-            identifiers={device_identifier(self.coordinator.entry_id, self._space_id)}
-        )
+        device_entry = find_device(device_registry, self.coordinator.entry_id, self._space_id)
         if not device_entry:
             _LOGGER.debug("No device entry found for %s", self._space_id)
             return

--- a/custom_components/ajax/camera.py
+++ b/custom_components/ajax/camera.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import AjaxConfigEntry
 from ._discovery import connect_new_entity_signal
-from ._ids import device_identifier
+from ._ids import device_identifier, via_device_info
 from .const import CONF_RTSP_PASSWORD, CONF_RTSP_USERNAME, MANUFACTURER, SIGNAL_NEW_VIDEO_EDGE
 from .coordinator import AjaxDataCoordinator
 from .models import VIDEO_EDGE_MODEL_NAMES, AjaxVideoEdge, VideoEdgeType
@@ -201,19 +201,19 @@ class AjaxVideoEdgeCamera(CoordinatorEntity[AjaxDataCoordinator], Camera):
 
         model_display = f"{self._model_name} ({self._color})" if self._color else self._model_name
 
-        # Determine via_device: if camera is recorded by NVR, link to NVR
+        # Determine the parent device: if the camera is recorded by an NVR, link to the NVR
         # Otherwise link to hub (space_id)
-        via_device_id = self._space_id
+        parent_id = self._space_id
         nvr_id = self._get_recording_nvr_id()
         if nvr_id:
-            via_device_id = nvr_id
+            parent_id = nvr_id
 
         return DeviceInfo(
             identifiers={device_identifier(self.coordinator.entry_id, video_edge.id)},
             name=video_edge.name,
             manufacturer=MANUFACTURER,
             model=model_display,
-            via_device=device_identifier(self.coordinator.entry_id, via_device_id),
+            **via_device_info(self.coordinator.hass, self.coordinator.entry_id, parent_id),
             sw_version=video_edge.firmware_version,
         )
 

--- a/custom_components/ajax/event.py
+++ b/custom_components/ajax/event.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import AjaxConfigEntry
 from ._discovery import connect_new_entity_signal
-from ._ids import device_identifier
+from ._ids import device_identifier, via_device_info
 from .const import MANUFACTURER, SIGNAL_NEW_DEVICE, SIGNAL_NEW_SMART_LOCK, SIGNAL_NEW_VIDEO_EDGE
 from .coordinator import AjaxDataCoordinator
 from .devices import get_device_handler
@@ -241,7 +241,7 @@ class AjaxEventEntity(CoordinatorEntity[AjaxDataCoordinator], EventEntity):
                     name=device.name,
                     manufacturer=MANUFACTURER,
                     model=device.type.value,
-                    via_device=device_identifier(self.coordinator.entry_id, space.id),
+                    **via_device_info(self.coordinator.hass, self.coordinator.entry_id, space.id),
                 )
             # Check video_edges (for doorbell)
             video_edge = space.video_edges.get(self._device_id)
@@ -252,7 +252,7 @@ class AjaxEventEntity(CoordinatorEntity[AjaxDataCoordinator], EventEntity):
                     name=video_edge.name,
                     manufacturer=MANUFACTURER,
                     model=model_name,
-                    via_device=device_identifier(self.coordinator.entry_id, space.id),
+                    **via_device_info(self.coordinator.hass, self.coordinator.entry_id, space.id),
                 )
             # Check smart_locks
             smart_lock = space.smart_locks.get(self._device_id)
@@ -262,7 +262,7 @@ class AjaxEventEntity(CoordinatorEntity[AjaxDataCoordinator], EventEntity):
                     name=smart_lock.name,
                     manufacturer=MANUFACTURER,
                     model="LockBridge Jeweller",
-                    via_device=device_identifier(self.coordinator.entry_id, space.id),
+                    **via_device_info(self.coordinator.hass, self.coordinator.entry_id, space.id),
                 )
         return None
 

--- a/custom_components/ajax/light.py
+++ b/custom_components/ajax/light.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import AjaxConfigEntry
 from ._discovery import connect_new_entity_signal
-from ._ids import device_identifier
+from ._ids import device_identifier, via_device_info
 from .const import DOMAIN, MANUFACTURER, SIGNAL_NEW_DEVICE
 from .coordinator import AjaxDataCoordinator
 from .devices import is_dimmer_device
@@ -123,7 +123,7 @@ class AjaxDimmerLight(CoordinatorEntity[AjaxDataCoordinator], LightEntity):
             manufacturer=MANUFACTURER,
             model=device.raw_type or "LightSwitch Dimmer",
             sw_version=device.firmware_version,
-            via_device=device_identifier(self.coordinator.entry_id, self._space_id),
+            **via_device_info(self.coordinator.hass, self.coordinator.entry_id, self._space_id),
         )
 
     @property

--- a/custom_components/ajax/lock.py
+++ b/custom_components/ajax/lock.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import AjaxConfigEntry
 from ._discovery import connect_new_entity_signal
-from ._ids import device_identifier
+from ._ids import device_identifier, via_device_info
 from .const import DOMAIN, MANUFACTURER, SIGNAL_NEW_SMART_LOCK
 from .coordinator import AjaxDataCoordinator
 from .models import AjaxSmartLock
@@ -201,7 +201,7 @@ class AjaxLock(CoordinatorEntity[AjaxDataCoordinator], LockEntity):
             name=smart_lock.name,
             manufacturer=MANUFACTURER,
             model="LockBridge Jeweller",
-            via_device=device_identifier(self.coordinator.entry_id, self._space_id),
+            **via_device_info(self.coordinator.hass, self.coordinator.entry_id, self._space_id),
         )
 
     def _get_smart_lock(self) -> AjaxSmartLock | None:

--- a/custom_components/ajax/quality_scale.yaml
+++ b/custom_components/ajax/quality_scale.yaml
@@ -157,7 +157,7 @@ rules:
       Each platform exposes a `DeviceInfo` with `identifiers`, `name`,
       `manufacturer="Ajax Systems"`, `model` (device-type display name) and
       `sw_version` / `hw_version` (sourced from the Ajax API on every
-      poll). NVR-channel cameras link back to the parent NVR via `via_device`.
+      poll). NVR-channel cameras link back to the parent NVR via `via_device_id`.
   diagnostics:
     status: done
     comment: |

--- a/custom_components/ajax/valve.py
+++ b/custom_components/ajax/valve.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import AjaxConfigEntry
 from ._discovery import connect_new_entity_signal
-from ._ids import device_identifier
+from ._ids import device_identifier, via_device_info
 from .const import DOMAIN, MANUFACTURER, SIGNAL_NEW_DEVICE
 from .coordinator import AjaxDataCoordinator
 from .devices import WaterStopHandler
@@ -251,7 +251,7 @@ class AjaxValve(CoordinatorEntity[AjaxDataCoordinator], ValveEntity):
             name=device.name,
             manufacturer=MANUFACTURER,
             model="WaterStop",
-            via_device=device_identifier(self.coordinator.entry_id, self._space_id),
+            **via_device_info(self.coordinator.hass, self.coordinator.entry_id, self._space_id),
             sw_version=device.attributes.get("firmwareVersion"),
             suggested_area=device.room_name,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Collection, Generator
 from types import SimpleNamespace
 
 import pytest
@@ -34,13 +34,26 @@ class _FakeDeviceRegistry:
     unit tests bypass the HA harness entirely (``object.__new__`` + stubbed
     coordinator), so they get this stand-in instead: every identifier resolves
     to a stable, predictable device id.
+
+    That models the production invariant — hubs and NVRs are pre-registered
+    before the platforms run — so the parent is always found. Pass ``missing``
+    to model the opposite and check that the link is dropped rather than set
+    to a dangling id.
     """
 
-    def async_get_device_by_identifier(self, identifier: tuple[str, str], config_entry_id: str) -> SimpleNamespace:
-        """Resolve any identifier to a device whose id derives from it."""
+    def __init__(self, *, missing: Collection[str] = ()) -> None:
+        """Store the raw Ajax ids that must *not* resolve to a device."""
+        self._missing = set(missing)
+
+    def async_get_device_by_identifier(
+        self, identifier: tuple[str, str], config_entry_id: str
+    ) -> SimpleNamespace | None:
+        """Resolve an identifier to a device whose id derives from it."""
+        if any(identifier[1].endswith(f"_{raw_id}") for raw_id in self._missing):
+            return None
         return SimpleNamespace(id=f"dev_{identifier[1]}")
 
-    def async_get_device(self, identifiers: set[tuple[str, str]]) -> SimpleNamespace:
+    def async_get_device(self, identifiers: set[tuple[str, str]]) -> SimpleNamespace | None:
         """Same resolution through the pre-2026.8 lookup."""
         return self.async_get_device_by_identifier(next(iter(identifiers)), "")
 
@@ -50,6 +63,9 @@ def fake_device_id(entry_id: str, raw_id: str) -> str:
     return f"dev_{entry_id}_{raw_id}"
 
 
-def fake_hass() -> SimpleNamespace:
-    """Return a stand-in ``hass`` that ``device_registry.async_get`` accepts."""
-    return SimpleNamespace(data={dr.DATA_REGISTRY: _FakeDeviceRegistry()})
+def fake_hass(*, missing: Collection[str] = ()) -> SimpleNamespace:
+    """Return a stand-in ``hass`` that ``device_registry.async_get`` accepts.
+
+    ``missing`` lists raw Ajax ids the registry must not know about.
+    """
+    return SimpleNamespace(data={dr.DATA_REGISTRY: _FakeDeviceRegistry(missing=missing)})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from types import SimpleNamespace
 
 import pytest
+from homeassistant.helpers import device_registry as dr
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -22,3 +24,32 @@ def enable_event_loop_debug() -> None:
 def verify_cleanup() -> Generator[None]:
     """Override HA cleanup fixture for non-HA translation tests."""
     yield
+
+
+class _FakeDeviceRegistry:
+    """Minimal device registry for the entity unit tests.
+
+    ``DeviceInfo`` links its parent with ``via_device_id``, a device-registry
+    id, so building a ``device_info`` now needs a registry lookup. The entity
+    unit tests bypass the HA harness entirely (``object.__new__`` + stubbed
+    coordinator), so they get this stand-in instead: every identifier resolves
+    to a stable, predictable device id.
+    """
+
+    def async_get_device_by_identifier(self, identifier: tuple[str, str], config_entry_id: str) -> SimpleNamespace:
+        """Resolve any identifier to a device whose id derives from it."""
+        return SimpleNamespace(id=f"dev_{identifier[1]}")
+
+    def async_get_device(self, identifiers: set[tuple[str, str]]) -> SimpleNamespace:
+        """Same resolution through the pre-2026.8 lookup."""
+        return self.async_get_device_by_identifier(next(iter(identifiers)), "")
+
+
+def fake_device_id(entry_id: str, raw_id: str) -> str:
+    """Return the device id ``_FakeDeviceRegistry`` resolves an Ajax object to."""
+    return f"dev_{entry_id}_{raw_id}"
+
+
+def fake_hass() -> SimpleNamespace:
+    """Return a stand-in ``hass`` that ``device_registry.async_get`` accepts."""
+    return SimpleNamespace(data={dr.DATA_REGISTRY: _FakeDeviceRegistry()})

--- a/tests/test_camera_light_coverage.py
+++ b/tests/test_camera_light_coverage.py
@@ -205,6 +205,17 @@ def test_device_info_links_to_recording_nvr() -> None:
     assert cam.device_info["via_device_id"] == fake_device_id("entry_test", "nvr-99")
 
 
+def test_device_info_omits_parent_when_nvr_not_registered() -> None:
+    """An unregistered parent drops the link; a dangling id would be rejected."""
+    cam = _camera(video_edge=_video_edge())
+    cam._get_recording_nvr_id = lambda: "nvr-99"
+    cam.coordinator.hass = fake_hass(missing=["nvr-99"])
+
+    info = cam.device_info
+    assert "via_device_id" not in info
+    assert info["identifiers"] == {("ajax", "entry_test_ve1")}
+
+
 # ---------------------------------------------------------------------------
 # Camera: _get_recording_nvr_id
 # ---------------------------------------------------------------------------

--- a/tests/test_camera_light_coverage.py
+++ b/tests/test_camera_light_coverage.py
@@ -58,6 +58,7 @@ from custom_components.ajax.models import (
     DeviceType,
     VideoEdgeType,
 )
+from tests.conftest import fake_device_id, fake_hass
 
 # ---------------------------------------------------------------------------
 # Camera helpers
@@ -128,6 +129,7 @@ def _camera(
     cam.coordinator = SimpleNamespace(
         last_update_success=True,
         entry_id="entry_test",
+        hass=fake_hass(),
         data=SimpleNamespace(spaces={"s1": space}),
         get_space=lambda sid: space if sid == "s1" else None,
     )
@@ -185,7 +187,7 @@ def test_device_info_standalone_links_to_hub() -> None:
     assert info["identifiers"] == {("ajax", "entry_test_ve1")}
     assert info["name"] == "Front Door Cam"
     assert info["model"] == "TurretCam (White)"
-    assert info["via_device"] == ("ajax", "entry_test_s1")
+    assert info["via_device_id"] == fake_device_id("entry_test", "s1")
     assert info["sw_version"] == "1.2.3"
 
 
@@ -200,7 +202,7 @@ def test_device_info_links_to_recording_nvr() -> None:
     ve = _video_edge()
     cam = _camera(video_edge=ve)
     cam._get_recording_nvr_id = lambda: "nvr-99"
-    assert cam.device_info["via_device"] == ("ajax", "entry_test_nvr-99")
+    assert cam.device_info["via_device_id"] == fake_device_id("entry_test", "nvr-99")
 
 
 # ---------------------------------------------------------------------------
@@ -495,6 +497,7 @@ def _light(
     )
     light.coordinator = SimpleNamespace(
         entry_id="entry_test",
+        hass=fake_hass(),
         get_space=lambda sid: space if sid == "s1" else None,
         last_update_success=update_success,
         api=api,
@@ -526,7 +529,7 @@ def test_light_device_info() -> None:
     assert info["name"] == "Dimmer Lounge"
     assert info["model"] == "LightSwitchDimmer"
     assert info["sw_version"] == "2.0.0"
-    assert info["via_device"] == ("ajax", "entry_test_s1")
+    assert info["via_device_id"] == fake_device_id("entry_test", "s1")
 
 
 def test_light_device_info_default_model_when_no_raw_type() -> None:
@@ -727,6 +730,7 @@ async def test_turn_off_rollback_pops_unset_attrs() -> None:
 def _setup_coordinator(spaces: dict[str, AjaxSpace], *, account: bool = False) -> SimpleNamespace:
     coord = SimpleNamespace(
         entry_id="entry_test",
+        hass=fake_hass(),
         data=SimpleNamespace(spaces=spaces),
         get_space=lambda sid: spaces.get(sid),
     )

--- a/tests/test_coordinator_devices_coverage.py
+++ b/tests/test_coordinator_devices_coverage.py
@@ -897,6 +897,7 @@ async def test_update_devices_absent_device_removed_after_threshold() -> None:
 
     registry = MagicMock()
     registry.async_get_device_by_identifier = MagicMock(return_value=None)
+    registry.async_get_device = MagicMock(return_value=None)
     with patch(
         "custom_components.ajax._coordinator_devices.dr.async_get",
         return_value=registry,
@@ -1243,6 +1244,7 @@ async def test_update_devices_removed_device_unregistered_from_ha() -> None:
     ha_device = SimpleNamespace(id="ha-ghost")
     registry = MagicMock()
     registry.async_get_device_by_identifier = MagicMock(return_value=ha_device)
+    registry.async_get_device = MagicMock(return_value=ha_device)
     registry.async_remove_device = MagicMock()
     with patch(
         "custom_components.ajax._coordinator_devices.dr.async_get",

--- a/tests/test_coordinator_devices_coverage.py
+++ b/tests/test_coordinator_devices_coverage.py
@@ -896,7 +896,7 @@ async def test_update_devices_absent_device_removed_after_threshold() -> None:
     mixin = _make_mixin(account=account, devices_list=payload)
 
     registry = MagicMock()
-    registry.async_get_device = MagicMock(return_value=None)
+    registry.async_get_device_by_identifier = MagicMock(return_value=None)
     with patch(
         "custom_components.ajax._coordinator_devices.dr.async_get",
         return_value=registry,
@@ -1242,7 +1242,7 @@ async def test_update_devices_removed_device_unregistered_from_ha() -> None:
 
     ha_device = SimpleNamespace(id="ha-ghost")
     registry = MagicMock()
-    registry.async_get_device = MagicMock(return_value=ha_device)
+    registry.async_get_device_by_identifier = MagicMock(return_value=ha_device)
     registry.async_remove_device = MagicMock()
     with patch(
         "custom_components.ajax._coordinator_devices.dr.async_get",
@@ -1251,7 +1251,9 @@ async def test_update_devices_removed_device_unregistered_from_ha() -> None:
         await mixin._async_update_devices("s1")
 
     # Lookup uses the namespaced identifier (DOMAIN, "entry_test_ghost").
-    registry.async_get_device.assert_called_once_with(identifiers={device_identifier("entry_test", "ghost")})
+    registry.async_get_device_by_identifier.assert_called_once_with(
+        device_identifier("entry_test", "ghost"), "entry_test"
+    )
     registry.async_remove_device.assert_called_once_with("ha-ghost")
     assert "ghost" not in space.devices
 

--- a/tests/test_coordinator_state_coverage.py
+++ b/tests/test_coordinator_state_coverage.py
@@ -293,7 +293,7 @@ async def test_video_edges_cleanup_removes_stale_with_ha_device() -> None:
 
     registry = MagicMock()
     ha_device = MagicMock(id="dev-entry")
-    registry.async_get_device.return_value = ha_device
+    registry.async_get_device_by_identifier.return_value = ha_device
     with patch("custom_components.ajax._coordinator_state.dr.async_get", return_value=registry):
         await mixin._async_update_video_edges("s1")
 
@@ -301,7 +301,7 @@ async def test_video_edges_cleanup_removes_stale_with_ha_device() -> None:
     assert "kept" in space.video_edges
     registry.async_remove_device.assert_called_once_with("dev-entry")
     # The stale device is looked up by its entry-namespaced identifier.
-    registry.async_get_device.assert_called_once_with(identifiers={(DOMAIN, "entry_test_stale")})
+    registry.async_get_device_by_identifier.assert_called_once_with((DOMAIN, "entry_test_stale"), "entry_test")
 
 
 @pytest.mark.asyncio
@@ -312,7 +312,7 @@ async def test_video_edges_cleanup_no_ha_device() -> None:
     mixin.api.async_get_video_edges = AsyncMock(return_value=[{"id": "kept", "type": "NVR"}])
 
     registry = MagicMock()
-    registry.async_get_device.return_value = None
+    registry.async_get_device_by_identifier.return_value = None
     with patch("custom_components.ajax._coordinator_state.dr.async_get", return_value=registry):
         await mixin._async_update_video_edges("s1")
 
@@ -433,7 +433,7 @@ async def test_smart_locks_cleanup_removes_api_lock_preserves_sse_lock() -> None
     mixin.api.async_get_smart_locks = AsyncMock(return_value=[{"id": "kept", "name": "Kept", "type": "smartlock"}])
 
     registry = MagicMock()
-    registry.async_get_device.return_value = MagicMock(id="dev-1")
+    registry.async_get_device_by_identifier.return_value = MagicMock(id="dev-1")
     with patch("custom_components.ajax._coordinator_state.dr.async_get", return_value=registry):
         await mixin._async_update_smart_locks("s1")
 
@@ -442,7 +442,7 @@ async def test_smart_locks_cleanup_removes_api_lock_preserves_sse_lock() -> None
     assert "kept" in space.smart_locks
     registry.async_remove_device.assert_called_once_with("dev-1")
     # The stale API lock is looked up by its entry-namespaced identifier.
-    registry.async_get_device.assert_called_once_with(identifiers={(DOMAIN, "entry_test_api_gone")})
+    registry.async_get_device_by_identifier.assert_called_once_with((DOMAIN, "entry_test_api_gone"), "entry_test")
 
 
 @pytest.mark.asyncio
@@ -454,7 +454,7 @@ async def test_smart_locks_cleanup_no_ha_device() -> None:
     mixin = _ve_mixin(space)
     mixin.api.async_get_smart_locks = AsyncMock(return_value=[{"id": "kept", "name": "Kept", "type": "smartlock"}])
     registry = MagicMock()
-    registry.async_get_device.return_value = None
+    registry.async_get_device_by_identifier.return_value = None
     with patch("custom_components.ajax._coordinator_state.dr.async_get", return_value=registry):
         await mixin._async_update_smart_locks("s1")
     assert "api_gone" not in space.smart_locks

--- a/tests/test_coordinator_state_coverage.py
+++ b/tests/test_coordinator_state_coverage.py
@@ -294,6 +294,7 @@ async def test_video_edges_cleanup_removes_stale_with_ha_device() -> None:
     registry = MagicMock()
     ha_device = MagicMock(id="dev-entry")
     registry.async_get_device_by_identifier.return_value = ha_device
+    registry.async_get_device.return_value = ha_device
     with patch("custom_components.ajax._coordinator_state.dr.async_get", return_value=registry):
         await mixin._async_update_video_edges("s1")
 
@@ -313,6 +314,7 @@ async def test_video_edges_cleanup_no_ha_device() -> None:
 
     registry = MagicMock()
     registry.async_get_device_by_identifier.return_value = None
+    registry.async_get_device.return_value = None
     with patch("custom_components.ajax._coordinator_state.dr.async_get", return_value=registry):
         await mixin._async_update_video_edges("s1")
 
@@ -434,6 +436,7 @@ async def test_smart_locks_cleanup_removes_api_lock_preserves_sse_lock() -> None
 
     registry = MagicMock()
     registry.async_get_device_by_identifier.return_value = MagicMock(id="dev-1")
+    registry.async_get_device.return_value = registry.async_get_device_by_identifier.return_value
     with patch("custom_components.ajax._coordinator_state.dr.async_get", return_value=registry):
         await mixin._async_update_smart_locks("s1")
 
@@ -455,6 +458,7 @@ async def test_smart_locks_cleanup_no_ha_device() -> None:
     mixin.api.async_get_smart_locks = AsyncMock(return_value=[{"id": "kept", "name": "Kept", "type": "smartlock"}])
     registry = MagicMock()
     registry.async_get_device_by_identifier.return_value = None
+    registry.async_get_device.return_value = None
     with patch("custom_components.ajax._coordinator_state.dr.async_get", return_value=registry):
         await mixin._async_update_smart_locks("s1")
     assert "api_gone" not in space.smart_locks

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -24,8 +24,20 @@ def fake_hass() -> SimpleNamespace:
 
 @pytest.fixture
 def fake_entry() -> SimpleNamespace:
-    entry = SimpleNamespace(async_on_unload=MagicMock())
+    entry = SimpleNamespace(async_on_unload=MagicMock(), runtime_data=MagicMock())
     return entry
+
+
+@pytest.fixture
+def mock_register_parents():
+    """Stub the parent-device pre-registration the helper triggers.
+
+    Newly-discovered entities link to their parent by device-registry id, so
+    the helper registers hubs/NVRs before adding them. That needs a real
+    registry, which these dispatcher-level tests deliberately do without.
+    """
+    with patch.object(_discovery, "async_register_parent_devices") as mock:
+        yield mock
 
 
 def _registry(*existing_unique_ids: str) -> MagicMock:
@@ -55,6 +67,7 @@ def test_adds_only_unknown_entities(
     mock_er,
     fake_hass,
     fake_entry,
+    mock_register_parents,
 ) -> None:
     # Dedup is on entity.unique_id, so fake entities must carry it.
     ent_new = SimpleNamespace(unique_id="uid_new")
@@ -136,6 +149,7 @@ def test_passes_signal_and_domain_through(
     mock_er,
     fake_hass,
     fake_entry,
+    mock_register_parents,
 ) -> None:
     builder = MagicMock(return_value=[])
     mock_er.async_get.return_value = _registry()
@@ -149,3 +163,46 @@ def test_passes_signal_and_domain_through(
     builder.return_value = [("uid", SimpleNamespace(unique_id="uid"))]
     handler("s", "o")
     mock_er.async_get.return_value.async_get_entity_id.assert_called_with("event", _discovery.DOMAIN, "uid")
+
+
+@patch.object(_discovery, "er")
+@patch.object(_discovery, "async_dispatcher_connect")
+def test_registers_parent_devices_before_adding(
+    mock_dispatcher_connect,
+    mock_er,
+    fake_hass,
+    fake_entry,
+    mock_register_parents,
+) -> None:
+    """Parents are registered before the entities that link to them are added."""
+    entity = SimpleNamespace(unique_id="uid_new")
+    builder = MagicMock(return_value=[("uid_new", entity)])
+    mock_er.async_get.return_value = _registry()
+
+    async_add = _connect(fake_hass, fake_entry, builder)
+    handler = mock_dispatcher_connect.call_args.args[2]
+    handler("space-1", "obj-1")
+
+    mock_register_parents.assert_called_once_with(fake_hass, fake_entry, fake_entry.runtime_data)
+    async_add.assert_called_once_with([entity])
+
+
+@patch.object(_discovery, "er")
+@patch.object(_discovery, "async_dispatcher_connect")
+def test_no_parent_registration_when_nothing_to_add(
+    mock_dispatcher_connect,
+    mock_er,
+    fake_hass,
+    fake_entry,
+    mock_register_parents,
+) -> None:
+    """A signal that yields no fresh entity touches neither registry."""
+    entity = SimpleNamespace(unique_id="uid_seen")
+    builder = MagicMock(return_value=[("uid_seen", entity)])
+    mock_er.async_get.return_value = _registry("uid_seen")
+
+    _connect(fake_hass, fake_entry, builder)
+    handler = mock_dispatcher_connect.call_args.args[2]
+    handler("space-1", "obj-1")
+
+    mock_register_parents.assert_not_called()

--- a/tests/test_event_button_coverage.py
+++ b/tests/test_event_button_coverage.py
@@ -35,6 +35,7 @@ from custom_components.ajax.models import (
     DeviceType,
     VideoEdgeType,
 )
+from tests.conftest import fake_hass
 
 # ---------------------------------------------------------------------------
 # Builders
@@ -84,6 +85,7 @@ def _event_coordinator(account: AjaxAccount | None):
     space = account.spaces["s1"] if account else None
     return SimpleNamespace(
         entry_id="entry_test",
+        hass=fake_hass(),
         account=account,
         get_space=lambda sid: space if sid == "s1" else None,
         _event_entities={},
@@ -110,7 +112,9 @@ def _make_event(
     entity._attr_event_types = list(event_types)
     entity.hass = None
     entity._trigger_event = MagicMock()
-    entity.coordinator = coordinator or SimpleNamespace(entry_id="entry_test", _event_entities={}, account=None)
+    entity.coordinator = coordinator or SimpleNamespace(
+        entry_id="entry_test", hass=fake_hass(), _event_entities={}, account=None
+    )
     return entity
 
 
@@ -124,7 +128,9 @@ def test_fire_writes_ha_state_when_hass_present() -> None:
 
 
 def test_device_info_returns_none_when_account_missing() -> None:
-    entity = _make_event(coordinator=SimpleNamespace(entry_id="entry_test", _event_entities={}, account=None))
+    entity = _make_event(
+        coordinator=SimpleNamespace(entry_id="entry_test", hass=fake_hass(), _event_entities={}, account=None)
+    )
     assert entity.device_info is None
 
 
@@ -287,6 +293,7 @@ async def test_event_setup_entry_dedupes_duplicate_unique_ids() -> None:
     account.spaces["s2"] = space2
     coordinator = SimpleNamespace(
         entry_id="entry_test",
+        hass=fake_hass(),
         account=account,
         get_space=lambda sid: account.spaces.get(sid),
         _event_entities={},
@@ -404,6 +411,7 @@ def _make_panic(*, space) -> AjaxPanicButton:
     button._last_press_ts = 0.0
     button.coordinator = SimpleNamespace(
         entry_id="entry_test",
+        hass=fake_hass(),
         async_press_panic_button=AsyncMock(),
         get_space=lambda sid: space if sid == "s1" else None,
     )

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,0 +1,87 @@
+"""Unit tests for the registry-identifier helpers.
+
+``_ids`` is the single source of truth for how an Ajax object is addressed
+in the device registry: the namespaced identifier, the parent link, and the
+entry-scoped lookup. Two of the three have a version-dependent shape — the
+integration supports cores both before and after the 2026.8 deprecation of
+``DeviceInfo.via_device`` — so both branches are exercised here.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from custom_components.ajax._ids import device_identifier, find_device, via_device_info
+from custom_components.ajax.const import DOMAIN
+from tests.conftest import _FakeDeviceRegistry, fake_device_id, fake_hass
+
+
+def test_device_identifier_is_entry_namespaced() -> None:
+    assert device_identifier("entry_test", "s1") == (DOMAIN, "entry_test_s1")
+
+
+# ---------------------------------------------------------------------------
+# via_device_info
+# ---------------------------------------------------------------------------
+
+
+def test_via_device_info_uses_registry_id_on_recent_core() -> None:
+    info = via_device_info(fake_hass(), "entry_test", "s1")
+
+    assert info == {"via_device_id": fake_device_id("entry_test", "s1")}
+
+
+def test_via_device_info_omits_link_when_parent_unregistered() -> None:
+    """A dangling via_device_id is rejected by HA, so the key must be dropped."""
+    info = via_device_info(fake_hass(missing=["s1"]), "entry_test", "s1")
+
+    assert info == {}
+
+
+def test_via_device_info_falls_back_to_tuple_on_old_core() -> None:
+    """Cores older than 2026.8 do not know via_device_id at all."""
+    with patch("custom_components.ajax._ids._SUPPORTS_VIA_DEVICE_ID", False):
+        info = via_device_info(fake_hass(), "entry_test", "s1")
+
+    assert info == {"via_device": (DOMAIN, "entry_test_s1")}
+
+
+def test_via_device_info_old_core_does_not_touch_the_registry() -> None:
+    """The tuple form is resolved by HA itself — no lookup to make here."""
+    hass = SimpleNamespace(data={})  # dr.async_get would raise on this one
+
+    with patch("custom_components.ajax._ids._SUPPORTS_VIA_DEVICE_ID", False):
+        assert via_device_info(hass, "entry_test", "s1") == {"via_device": (DOMAIN, "entry_test_s1")}
+
+
+# ---------------------------------------------------------------------------
+# find_device
+# ---------------------------------------------------------------------------
+
+
+def test_find_device_resolves_through_the_entry_scoped_lookup() -> None:
+    registry = _FakeDeviceRegistry()
+
+    device = find_device(registry, "entry_test", "d1")
+
+    assert device is not None
+    assert device.id == fake_device_id("entry_test", "d1")
+
+
+def test_find_device_returns_none_for_an_unknown_object() -> None:
+    registry = _FakeDeviceRegistry(missing=["d1"])
+
+    assert find_device(registry, "entry_test", "d1") is None
+
+
+def test_find_device_falls_back_to_the_legacy_lookup_on_old_core() -> None:
+    """Pre-2026.8 registries only expose async_get_device(identifiers=...)."""
+    registry = SimpleNamespace(
+        async_get_device=lambda identifiers: SimpleNamespace(id=f"legacy_{next(iter(identifiers))[1]}")
+    )
+
+    with patch("custom_components.ajax._ids._SUPPORTS_VIA_DEVICE_ID", False):
+        device = find_device(registry, "entry_test", "d1")
+
+    assert device.id == "legacy_entry_test_d1"

--- a/tests/test_init_coverage.py
+++ b/tests/test_init_coverage.py
@@ -889,7 +889,7 @@ async def test_setup_areas_creates_area_and_assigns_device() -> None:
 
     device_reg = MagicMock()
     ha_device = SimpleNamespace(id="ha-dev", area_id=None)
-    device_reg.async_get_device.return_value = ha_device
+    device_reg.async_get_device_by_identifier.return_value = ha_device
 
     with (
         patch("custom_components.ajax.ar.async_get", return_value=area_reg),
@@ -919,7 +919,7 @@ async def test_setup_areas_respects_existing_area_and_assignment() -> None:
 
     device_reg = MagicMock()
     # d1 already has an area assigned -> skipped
-    device_reg.async_get_device.return_value = SimpleNamespace(id="x", area_id="set")
+    device_reg.async_get_device_by_identifier.return_value = SimpleNamespace(id="x", area_id="set")
 
     with (
         patch("custom_components.ajax.ar.async_get", return_value=area_reg),
@@ -945,7 +945,7 @@ async def test_setup_areas_missing_ha_device_skipped() -> None:
     area_reg = MagicMock()
     area_reg.async_get_area_by_name.return_value = SimpleNamespace(id="a")
     device_reg = MagicMock()
-    device_reg.async_get_device.return_value = None  # not in registry
+    device_reg.async_get_device_by_identifier.return_value = None  # not in registry
 
     with (
         patch("custom_components.ajax.ar.async_get", return_value=area_reg),

--- a/tests/test_init_coverage.py
+++ b/tests/test_init_coverage.py
@@ -890,6 +890,7 @@ async def test_setup_areas_creates_area_and_assigns_device() -> None:
     device_reg = MagicMock()
     ha_device = SimpleNamespace(id="ha-dev", area_id=None)
     device_reg.async_get_device_by_identifier.return_value = ha_device
+    device_reg.async_get_device.return_value = ha_device
 
     with (
         patch("custom_components.ajax.ar.async_get", return_value=area_reg),
@@ -920,6 +921,7 @@ async def test_setup_areas_respects_existing_area_and_assignment() -> None:
     device_reg = MagicMock()
     # d1 already has an area assigned -> skipped
     device_reg.async_get_device_by_identifier.return_value = SimpleNamespace(id="x", area_id="set")
+    device_reg.async_get_device.return_value = device_reg.async_get_device_by_identifier.return_value
 
     with (
         patch("custom_components.ajax.ar.async_get", return_value=area_reg),
@@ -946,6 +948,7 @@ async def test_setup_areas_missing_ha_device_skipped() -> None:
     area_reg.async_get_area_by_name.return_value = SimpleNamespace(id="a")
     device_reg = MagicMock()
     device_reg.async_get_device_by_identifier.return_value = None  # not in registry
+    device_reg.async_get_device.return_value = None
 
     with (
         patch("custom_components.ajax.ar.async_get", return_value=area_reg),

--- a/tests/test_platforms_misc_coverage.py
+++ b/tests/test_platforms_misc_coverage.py
@@ -489,6 +489,7 @@ def test_update_device_registry_updates_existing_entry(monkeypatch: pytest.Monke
 
     registry = MagicMock()
     registry.async_get_device_by_identifier.return_value = SimpleNamespace(id="dev-entry-1")
+    registry.async_get_device.return_value = registry.async_get_device_by_identifier.return_value
     monkeypatch.setattr(
         "custom_components.ajax.alarm_control_panel.dr.async_get",
         lambda _hass: registry,
@@ -511,6 +512,7 @@ def test_update_device_registry_noop_when_entry_missing(monkeypatch: pytest.Monk
 
     registry = MagicMock()
     registry.async_get_device_by_identifier.return_value = None
+    registry.async_get_device.return_value = None
     monkeypatch.setattr(
         "custom_components.ajax.alarm_control_panel.dr.async_get",
         lambda _hass: registry,

--- a/tests/test_platforms_misc_coverage.py
+++ b/tests/test_platforms_misc_coverage.py
@@ -46,6 +46,7 @@ from custom_components.ajax.models import (
     VideoEdgeType,
 )
 from custom_components.ajax.valve import AjaxValve
+from tests.conftest import fake_hass
 
 # ===========================================================================
 # logbook.py
@@ -487,7 +488,7 @@ def test_update_device_registry_updates_existing_entry(monkeypatch: pytest.Monke
     panel.hass = MagicMock()
 
     registry = MagicMock()
-    registry.async_get_device.return_value = SimpleNamespace(id="dev-entry-1")
+    registry.async_get_device_by_identifier.return_value = SimpleNamespace(id="dev-entry-1")
     monkeypatch.setattr(
         "custom_components.ajax.alarm_control_panel.dr.async_get",
         lambda _hass: registry,
@@ -509,7 +510,7 @@ def test_update_device_registry_noop_when_entry_missing(monkeypatch: pytest.Monk
     panel.hass = MagicMock()
 
     registry = MagicMock()
-    registry.async_get_device.return_value = None
+    registry.async_get_device_by_identifier.return_value = None
     monkeypatch.setattr(
         "custom_components.ajax.alarm_control_panel.dr.async_get",
         lambda _hass: registry,
@@ -774,7 +775,9 @@ def _event_entity(*, account_spaces: dict | None) -> AjaxEventEntity:
     ent = object.__new__(AjaxEventEntity)
     ent._device_id = "x1"
     account = SimpleNamespace(spaces=account_spaces) if account_spaces is not None else None
-    ent.coordinator = SimpleNamespace(last_update_success=True, account=account, entry_id="entry_test")
+    ent.coordinator = SimpleNamespace(
+        last_update_success=True, account=account, entry_id="entry_test", hass=fake_hass()
+    )
     return ent
 
 
@@ -855,7 +858,9 @@ def _lock(smart_lock: AjaxSmartLock | None) -> AjaxLock:
     lock._space_id = "s1"
     lock._smart_lock_id = "sl1"
     space = SimpleNamespace(smart_locks={"sl1": smart_lock} if smart_lock else {})
-    lock.coordinator = SimpleNamespace(last_update_success=True, get_space=lambda sid: space, entry_id="entry_test")
+    lock.coordinator = SimpleNamespace(
+        last_update_success=True, get_space=lambda sid: space, entry_id="entry_test", hass=fake_hass()
+    )
     return lock
 
 
@@ -909,7 +914,9 @@ def test_lock_get_smart_lock_none_when_space_missing() -> None:
 def _tracker(space: SimpleNamespace | None) -> AjaxHubTracker:
     tracker = object.__new__(AjaxHubTracker)
     tracker._space_id = "s1"
-    tracker.coordinator = SimpleNamespace(last_update_success=True, get_space=lambda sid: space, entry_id="entry_test")
+    tracker.coordinator = SimpleNamespace(
+        last_update_success=True, get_space=lambda sid: space, entry_id="entry_test", hass=fake_hass()
+    )
     return tracker
 
 
@@ -933,7 +940,9 @@ def _geofence_tracker(geofence: dict) -> AjaxHubTracker:
     space = SimpleNamespace(hub_details={"geoFence": geofence}, hub_id="hub1", name="Maison")
     tracker = object.__new__(AjaxHubTracker)
     tracker._space_id = "s1"
-    tracker.coordinator = SimpleNamespace(last_update_success=True, get_space=lambda sid: space, entry_id="entry_test")
+    tracker.coordinator = SimpleNamespace(
+        last_update_success=True, get_space=lambda sid: space, entry_id="entry_test", hass=fake_hass()
+    )
     return tracker
 
 

--- a/tests/test_sensor_binary_coverage.py
+++ b/tests/test_sensor_binary_coverage.py
@@ -544,6 +544,7 @@ def test_binary_sensor_update_device_registry_updates_entry() -> None:
     device_entry = SimpleNamespace(id="entry-id")
     registry = MagicMock()
     registry.async_get_device_by_identifier.return_value = device_entry
+    registry.async_get_device.return_value = device_entry
 
     with patch("custom_components.ajax._binary_sensor_entities.dr.async_get", return_value=registry):
         sensor._update_device_registry()
@@ -568,6 +569,7 @@ def test_binary_sensor_update_device_registry_noop_when_entry_missing() -> None:
     sensor.hass = MagicMock()
     registry = MagicMock()
     registry.async_get_device_by_identifier.return_value = None
+    registry.async_get_device.return_value = None
     with patch("custom_components.ajax._binary_sensor_entities.dr.async_get", return_value=registry):
         sensor._update_device_registry()
     registry.async_update_device.assert_not_called()

--- a/tests/test_sensor_binary_coverage.py
+++ b/tests/test_sensor_binary_coverage.py
@@ -7,7 +7,7 @@ uncovered:
 - the pure formatting helpers in ``sensor.py`` (``format_*``,
   ``get_last_event_*``, ``_format_time_ago``);
 - the ``device_info`` properties of every entity class (model naming,
-  via_device / NVR linking, hub firmware);
+  parent-device / NVR linking, hub firmware);
 - the hub/smart-lock binary sensors (``AjaxHubBinarySensor`` value_key vs
   value_fn, ``AjaxSmartLockBinarySensor`` door state);
 - the registry-update path of ``AjaxBinarySensor``;
@@ -59,6 +59,7 @@ from custom_components.ajax.sensor import (
     get_last_event_attributes,
     get_last_event_text,
 )
+from tests.conftest import fake_device_id, fake_hass
 
 # ===========================================================================
 # sensor.py — pure formatting helpers
@@ -229,7 +230,9 @@ def test_space_sensor_device_info_with_firmware_and_subtype() -> None:
     sensor = object.__new__(AjaxSpaceSensor)
     sensor._space_id = "s1"
     sensor.entity_description = AjaxSpaceSensorDescription(key="x", value_fn=lambda s: 0)
-    sensor.coordinator = SimpleNamespace(last_update_success=True, get_space=lambda sid: space, entry_id="entry_test")
+    sensor.coordinator = SimpleNamespace(
+        last_update_success=True, get_space=lambda sid: space, entry_id="entry_test", hass=fake_hass()
+    )
 
     info = sensor.device_info
     assert info["identifiers"] == {("ajax", "entry_test_s1")}
@@ -244,7 +247,9 @@ def test_space_sensor_device_info_renames_bare_hub_and_defaults_model() -> None:
     sensor = object.__new__(AjaxSpaceSensor)
     sensor._space_id = "s1"
     sensor.entity_description = AjaxSpaceSensorDescription(key="x", value_fn=lambda s: 0)
-    sensor.coordinator = SimpleNamespace(last_update_success=True, get_space=lambda sid: space, entry_id="entry_test")
+    sensor.coordinator = SimpleNamespace(
+        last_update_success=True, get_space=lambda sid: space, entry_id="entry_test", hass=fake_hass()
+    )
 
     info = sensor.device_info
     assert info["name"] == "Ajax Hub"
@@ -302,7 +307,9 @@ def _device_sensor(device: AjaxDevice | None) -> AjaxDeviceSensor:
     sensor._sensor_key = "battery"
     sensor._sensor_desc = {"key": "battery"}
     space = SimpleNamespace(devices={"d1": device} if device else {})
-    sensor.coordinator = SimpleNamespace(get_space=lambda sid: space, last_update_success=True, entry_id="entry_test")
+    sensor.coordinator = SimpleNamespace(
+        get_space=lambda sid: space, last_update_success=True, entry_id="entry_test", hass=fake_hass()
+    )
     return sensor
 
 
@@ -316,7 +323,7 @@ def test_device_sensor_device_info() -> None:
     info = _device_sensor(device).device_info
     assert info["identifiers"] == {("ajax", "entry_test_d1")}
     assert info["model"] == "MotionProtect"
-    assert info["via_device"] == ("ajax", "entry_test_s1")
+    assert info["via_device_id"] == fake_device_id("entry_test", "s1")
     assert info["sw_version"] == "1.2"
     assert info["hw_version"] == "HW3"
     assert info["suggested_area"] == "Kitchen"
@@ -360,7 +367,9 @@ def _ve_sensor(video_edge: AjaxVideoEdge | None, *, nvr_id: str | None = None) -
         video_edges={"ve1": video_edge} if video_edge else {},
         get_recording_nvr_id=lambda cam_id: nvr_id,
     )
-    sensor.coordinator = SimpleNamespace(get_space=lambda sid: space, last_update_success=True, entry_id="entry_test")
+    sensor.coordinator = SimpleNamespace(
+        get_space=lambda sid: space, last_update_success=True, entry_id="entry_test", hass=fake_hass()
+    )
     return sensor
 
 
@@ -369,12 +378,12 @@ def test_ve_sensor_device_info_standalone_links_to_hub() -> None:
     assert info["identifiers"] == {("ajax", "entry_test_ve1")}
     # Human-readable model name plus colour suffix.
     assert info["model"] == "BulletCam (White)"
-    assert info["via_device"] == ("ajax", "entry_test_s1")
+    assert info["via_device_id"] == fake_device_id("entry_test", "s1")
 
 
 def test_ve_sensor_device_info_links_to_nvr_when_recorded() -> None:
     info = _ve_sensor(_video_edge(), nvr_id="nvr99").device_info
-    assert info["via_device"] == ("ajax", "entry_test_nvr99")
+    assert info["via_device_id"] == fake_device_id("entry_test", "nvr99")
 
 
 def test_ve_sensor_device_info_none_when_missing() -> None:
@@ -441,7 +450,9 @@ def test_hub_sensor_device_info_links_to_space() -> None:
     space = _hub_space()
     sensor = object.__new__(AjaxHubSensor)
     sensor._space_id = "s1"
-    sensor.coordinator = SimpleNamespace(last_update_success=True, get_space=lambda sid: space, entry_id="entry_test")
+    sensor.coordinator = SimpleNamespace(
+        last_update_success=True, get_space=lambda sid: space, entry_id="entry_test", hass=fake_hass()
+    )
     assert sensor.device_info["identifiers"] == {("ajax", "entry_test_s1")}
 
 
@@ -463,11 +474,13 @@ def test_smart_lock_sensor_device_info() -> None:
     sensor._space_id = "s1"
     sensor._smart_lock_id = "lock1"
     space = SimpleNamespace(smart_locks={"lock1": lock})
-    sensor.coordinator = SimpleNamespace(last_update_success=True, get_space=lambda sid: space, entry_id="entry_test")
+    sensor.coordinator = SimpleNamespace(
+        last_update_success=True, get_space=lambda sid: space, entry_id="entry_test", hass=fake_hass()
+    )
     info = sensor.device_info
     assert info["identifiers"] == {("ajax", "entry_test_lock1")}
     assert info["model"] == "LockBridge Jeweller"
-    assert info["via_device"] == ("ajax", "entry_test_s1")
+    assert info["via_device_id"] == fake_device_id("entry_test", "s1")
 
 
 def test_smart_lock_sensor_device_info_none_when_missing() -> None:
@@ -492,7 +505,9 @@ def _binary_sensor(device: AjaxDevice | None) -> AjaxBinarySensor:
     sensor._sensor_key = "motion"
     sensor._sensor_desc = {"key": "motion"}
     space = SimpleNamespace(devices={"d1": device} if device else {})
-    sensor.coordinator = SimpleNamespace(get_space=lambda sid: space, last_update_success=True, entry_id="entry_test")
+    sensor.coordinator = SimpleNamespace(
+        get_space=lambda sid: space, last_update_success=True, entry_id="entry_test", hass=fake_hass()
+    )
     return sensor
 
 
@@ -506,7 +521,7 @@ def test_binary_sensor_device_info_with_color() -> None:
     )
     info = _binary_sensor(device).device_info
     assert info["model"] == "DoorProtect Plus (White)"
-    assert info["via_device"] == ("ajax", "entry_test_s1")
+    assert info["via_device_id"] == fake_device_id("entry_test", "s1")
     assert info["suggested_area"] == "Garage"
 
 
@@ -528,7 +543,7 @@ def test_binary_sensor_update_device_registry_updates_entry() -> None:
 
     device_entry = SimpleNamespace(id="entry-id")
     registry = MagicMock()
-    registry.async_get_device.return_value = device_entry
+    registry.async_get_device_by_identifier.return_value = device_entry
 
     with patch("custom_components.ajax._binary_sensor_entities.dr.async_get", return_value=registry):
         sensor._update_device_registry()
@@ -552,7 +567,7 @@ def test_binary_sensor_update_device_registry_noop_when_entry_missing() -> None:
     sensor = _binary_sensor(_device())
     sensor.hass = MagicMock()
     registry = MagicMock()
-    registry.async_get_device.return_value = None
+    registry.async_get_device_by_identifier.return_value = None
     with patch("custom_components.ajax._binary_sensor_entities.dr.async_get", return_value=registry):
         sensor._update_device_registry()
     registry.async_update_device.assert_not_called()
@@ -587,7 +602,9 @@ def _ve_binary(video_edge: AjaxVideoEdge | None, *, nvr_id: str | None = None) -
         video_edges={"ve1": video_edge} if video_edge else {},
         get_recording_nvr_id=lambda cam_id: nvr_id,
     )
-    sensor.coordinator = SimpleNamespace(get_space=lambda sid: space, last_update_success=True, entry_id="entry_test")
+    sensor.coordinator = SimpleNamespace(
+        get_space=lambda sid: space, last_update_success=True, entry_id="entry_test", hass=fake_hass()
+    )
     return sensor
 
 
@@ -631,7 +648,7 @@ def test_ve_binary_extra_state_attributes() -> None:
 def test_ve_binary_device_info_links_to_nvr() -> None:
     info = _ve_binary(_video_edge(ve_type=VideoEdgeType.MINIDOME, color="black"), nvr_id="nvr1").device_info
     assert info["model"] == "MiniDome (Black)"
-    assert info["via_device"] == ("ajax", "entry_test_nvr1")
+    assert info["via_device_id"] == fake_device_id("entry_test", "nvr1")
 
 
 def test_ve_binary_device_info_none_when_missing() -> None:
@@ -649,7 +666,9 @@ def _hub_binary(sensor_key: str, hub_details: dict | None) -> AjaxHubBinarySenso
     sensor._space_id = "s1"
     sensor._sensor_key = sensor_key
     sensor._sensor_config = AjaxHubBinarySensor.HUB_BINARY_SENSORS.get(sensor_key, {})
-    sensor.coordinator = SimpleNamespace(last_update_success=True, get_space=lambda sid: space, entry_id="entry_test")
+    sensor.coordinator = SimpleNamespace(
+        last_update_success=True, get_space=lambda sid: space, entry_id="entry_test", hass=fake_hass()
+    )
     return sensor
 
 
@@ -733,7 +752,9 @@ def _sl_binary(lock: object | None) -> AjaxSmartLockBinarySensor:
     sensor._space_id = "s1"
     sensor._smart_lock_id = "lock1"
     space = SimpleNamespace(smart_locks={"lock1": lock} if lock else {})
-    sensor.coordinator = SimpleNamespace(last_update_success=True, get_space=lambda sid: space, entry_id="entry_test")
+    sensor.coordinator = SimpleNamespace(
+        last_update_success=True, get_space=lambda sid: space, entry_id="entry_test", hass=fake_hass()
+    )
     return sensor
 
 
@@ -756,7 +777,7 @@ def test_smart_lock_binary_device_info() -> None:
     info = _sl_binary(lock).device_info
     assert info["identifiers"] == {("ajax", "entry_test_lock1")}
     assert info["model"] == "LockBridge Jeweller"
-    assert info["via_device"] == ("ajax", "entry_test_s1")
+    assert info["via_device_id"] == fake_device_id("entry_test", "s1")
 
 
 def test_smart_lock_binary_device_info_none_when_missing() -> None:

--- a/tests/test_switch_coverage.py
+++ b/tests/test_switch_coverage.py
@@ -28,6 +28,7 @@ from custom_components.ajax.switch import (
     async_setup_entry,
     is_lightswitch_device,
 )
+from tests.conftest import fake_hass
 
 # ---------------------------------------------------------------------------
 # Builders
@@ -72,6 +73,7 @@ def _coordinator(
     )
     return SimpleNamespace(
         entry_id="entry_test",
+        hass=fake_hass(),
         get_space=lambda sid: space,
         last_update_success=True,
         api=api,
@@ -563,6 +565,7 @@ async def test_async_setup_entry_creates_relay_switch() -> None:
     account = _account_with(device)
     coordinator = SimpleNamespace(
         entry_id="entry_test",
+        hass=fake_hass(),
         account=account,
         get_space=account.spaces.get,
     )
@@ -589,6 +592,7 @@ async def test_async_setup_entry_creates_dimmer_switches() -> None:
     account = _account_with(device)
     coordinator = SimpleNamespace(
         entry_id="entry_test",
+        hass=fake_hass(),
         account=account,
         get_space=account.spaces.get,
     )
@@ -613,6 +617,7 @@ async def test_async_setup_entry_creates_lightswitch_settings_switches() -> None
     account = _account_with(device)
     coordinator = SimpleNamespace(
         entry_id="entry_test",
+        hass=fake_hass(),
         account=account,
         get_space=account.spaces.get,
     )
@@ -633,6 +638,7 @@ async def test_async_setup_entry_no_entities_skips_add() -> None:
     account = _account_with(device)
     coordinator = SimpleNamespace(
         entry_id="entry_test",
+        hass=fake_hass(),
         account=account,
         get_space=account.spaces.get,
     )
@@ -650,6 +656,7 @@ async def _capture_builder(device: AjaxDevice | None):
         space.devices[device.id] = device
     coordinator = SimpleNamespace(
         entry_id="entry_test",
+        hass=fake_hass(),
         account=AjaxAccount(user_id="u1", name="U", email="u@e.com", spaces={"s1": space}),
         get_space=lambda sid: space if sid == "s1" else None,
     )


### PR DESCRIPTION
## Le bug

On Home Assistant 2026.9, seven of the eight camera entities silently fail to register at setup:

```
ERROR [homeassistant.components.camera] Error adding entity None for domain camera with platform ajax   ×7
RuntimeError: Detected code that calls `device_registry.async_get_or_create`
              with a deprecated `via_device` parameter; use `via_device_id` instead
```

`DeviceInfo.via_device` (an identifier tuple) has been deprecated since 2026.8. The deprecation is normally reported as a warning, but the reporter needs an integration frame on the stack to attribute it — after the first `await` inside `_async_add_entity` there is none, so the report is raised as a `RuntimeError` instead. Only the first camera survived; the rest were dropped along with their entities.

Eight further deprecation warnings (`via_device`, `DeviceRegistry.async_get_device`) were on the same 2027.8 clock.

## The fix

Parent links are now device-registry ids:

- **`_ids.via_device_info()`** resolves the parent and returns the `DeviceInfo` fragment to merge. Falls back to the tuple form on cores older than 2026.8 — the HACS floor is 2025.11.
- **`_ids.find_device()`** replaces `DeviceRegistry.async_get_device`, deprecated because a bare identifier is not unique across config entries. Ajax identifiers are entry-namespaced, so both forms resolve to the same device.
- **`_device_parents.async_register_parent_devices()`** registers hubs and NVRs *before* the platforms are forwarded. A registry id only resolves once the parent exists, and platform order does not guarantee that: `camera` is set up before `sensor`, yet an NVR-channel camera's parent is first described by a sensor entity. The discovery path registers parents the same way before adding freshly-discovered entities.

14 call sites across 9 platforms, 6 registry lookups.

## Verification

On the dev instance (HA 2026.9.0b4), after redeploy:

- no error and no deprecation warning left for `ajax`
- the **8 camera entities** register
- device tree intact: `Maison → NVR → Caméra Devant / Sonnette`
- setup time **2.49s → 1.98s**

`ruff`, `ruff format`, `mypy --strict`: clean. **1993 tests pass.**

The entity unit tests build entities with `object.__new__` and a stubbed coordinator, which now needs a `hass` whose device registry answers the parent lookup — `tests/conftest.py` gains `fake_hass()` and `fake_device_id()` for that. Two tests were added covering the ordering between parent registration and entity addition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic registration of Ajax hubs and NVRs in the device registry.
  * Improved parent-device relationships for cameras, sensors, locks, switches, lights, and other entities.
* **Bug Fixes**
  * Improved device discovery and cleanup reliability across supported Home Assistant versions.
  * Updated registry handling for compatibility with newer Home Assistant APIs.
* **Tests**
  * Expanded coverage for parent-device registration, discovery, and device relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->